### PR TITLE
Allow adding annotations to service

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ securityContext: { }
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
 
 ingress:
   enabled: false

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/values.yaml
+++ b/values.yaml
@@ -171,6 +171,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 80
+  annotations: {}
 
 ingress:
   enabled: false


### PR DESCRIPTION
This will make it possible to add annotations to the service to for example attach [GKE BackendConfigs](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features#create_backendconfig) to the service.