### PR TITLE
Fix the URL linking to n8n configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The `values.yaml` file is divided into a n8n specific configuration section, and
 
 The shown values represent Helm defaults not application defaults. The comments behind the values provide a description and display the application default.
 
-Every possible n8n config can be set that are also described in the: [n8n configuration options](https://github.com/n8n-io/n8n/blob/master/packages/cli/config/index.ts).
+Every possible n8n config can be set that are also described in the: [n8n configuration options](https://github.com/n8n-io/n8n/blob/master/packages/cli/src/config/schema.ts).
 
 These n8n config options should be attached to Secret or Config.
 You decide what should be a secret and what should be a config the options are the same.


### PR DESCRIPTION
The old link goes to a 404 page. The new link goes to the correct file at the refactored location.