### PR TITLE
Add lifecycle configuration for main deployment

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,6 +44,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- include "n8n.deploymentPodEnvironments" . | nindent 12 }}
+          lifecycle:
+            {{- toYaml .Values.lifecycle | nindent 12 }}
           ports:
             - name: http
               containerPort: {{ get .Values.config "port" | default 5678 }}

--- a/values.yaml
+++ b/values.yaml
@@ -178,6 +178,17 @@ securityContext:
 # runAsNonRoot: true
 # runAsUser: 1000
 
+# here you can specify lifecycle hooks - it can be used e.g to easily add packages to the container without building
+# your own docker image
+lifecycle:
+  {}
+
+#  here's the sample configuration to add mysql-client to the container
+#lifecycle:
+#  postStart:
+#    exec:
+#      command: ["/bin/sh", "-c", "apk add mysql-client"]
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
Hello, 

Sometimes it doesn't make sense to build new docker image just to add some stuff to the main container.
In K8S we can use lifecycle parameter for container to inject some kind of actions.

This PR adds a configuration parameter "lifecycle" to the template to accomplish that.

Sample usage (values.yaml):

```
lifecycle:
  postStart:
    exec:
      command: ["/bin/sh", "-c", "apk add mysql-client"]
```