### PR TITLE
Conditionally add `N8N_ENCRYPTION_KEY` environment variable

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -67,11 +67,13 @@ Selector labels
 {{ end }}
 - name: "N8N_PORT" #! we better set the port once again as ENV Var, see: https://community.n8n.io/t/default-config-is-not-set-or-the-port-to-be-more-precise/3158/3?u=vad1mo
   value: {{ get .Values.config "port" | default "5678" | quote }}
+{{- if .Values.n8n.encryption_key }}
 - name: "N8N_ENCRYPTION_KEY"
   valueFrom:
     secretKeyRef:
       key:  N8N_ENCRYPTION_KEY
       name: {{ include "n8n.fullname" . }}
+{{- end }}
 {{- if or .Values.config .Values.secret }}
 - name: "N8N_CONFIG_FILES"
   value: {{ include "n8n.configFiles" . | quote }}
@@ -82,7 +84,7 @@ Selector labels
   value: "{{ .Values.scaling.redis.host }}"
   {{ else }}
   value: "{{ .Release.Name }}-redis-master"
-  {{ end }}  
+  {{ end }}
 - name: "EXECUTIONS_MODE"
   value: "queue"
 {{ end }}


### PR DESCRIPTION
Playing around with trying n8n, so I ran into a case where my minimally-defined configuration required no `secret` config since I'm using `extraSecretEnv` to set the database password. That means that the secret isn't getting created, and trying to set `N8N_ENCRYPTION_KEY` from a nonexistent Secret will fail the installation. (FWIW, I didn't configure `n8n.encryption_key` either)

This will conditionally set the environment variable if `.Values.n8n.encryption_key` is defined (which should also generate the secret).