### PR TITLE
Add ability to override command for main container

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/values.yaml
+++ b/values.yaml
@@ -200,6 +200,9 @@ lifecycle:
 #    exec:
 #      command: ["/bin/sh", "-c", "apk add mysql-client"]
 
+# here you can override a command for main container
+command: []
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
This simple change adds ability to override entrypoint for the container. 

---

Story behind the change: (if someone is interested or have similar issue)

I encountered strange issue while using volumes based on NFS as a storage for n8n and n8n was unable to execute entrypoint script due to immutable .snapshot directory on the mounted filesystem, so the only way to temporary hack it was to override entrypoint with my own version that does chown optionally and runs as root:

```yaml  
          command:
            - tini
            - --
            - /bin/sh
            - -c
            - chmod o+rx /root; chown -R node /root/.n8n || true; chown -R node /root/.n8n; ln -s /root/.n8n /home/node; chown -R node /home/node || true; node /usr/local/bin/n8n
```