### PR TITLE
Add support for "existing secrets"

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ config: # Dict with all n8n config options
 #      postgresdb:
 #        database: n8n
 #        host: localhost
+#
+# existingSecret: "" # Use an existing Kubernetes secret, e.g created by hand or Vault operator.
 secret: # Dict with all n8n config options, unlike config the values here will end up in a secret.
 #    database:
 #      postgresdb:

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ config: # Dict with all n8n config options
 #        database: n8n
 #        host: localhost
 #
+# existingSecret and secret are exclusive, with existingSecret taking priority.
 # existingSecret: "" # Use an existing Kubernetes secret, e.g created by hand or Vault operator.
 secret: # Dict with all n8n config options, unlike config the values here will end up in a secret.
 #    database:

--- a/templates/deployment.webhooks.yaml
+++ b/templates/deployment.webhooks.yaml
@@ -84,10 +84,10 @@ spec:
           configMap:
             name: {{ include "n8n.fullname" . }}
         {{- end }}
-        {{- if .Values.secret }}
+        {{- if or (.Values.secret) (.Values.existingSecret) }}
         - name: secret-volume
           secret:
-            secretName: {{ include "n8n.fullname" . }}
+            secretName: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ include "n8n.fullname" . }}{{ end }}
             items:
               - key: "secret.json"
                 path: "secret.json"

--- a/templates/deployment.worker.yaml
+++ b/templates/deployment.worker.yaml
@@ -84,10 +84,10 @@ spec:
           configMap:
             name: {{ include "n8n.fullname" . }}
         {{- end }}
-        {{- if .Values.secret }}
+        {{- if or (.Values.secret) (.Values.existingSecret) }}
         - name: secret-volume
           secret:
-            secretName: {{ include "n8n.fullname" . }}
+            secretName: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ include "n8n.fullname" . }}{{ end }}
             items:
               - key: "secret.json"
                 path: "secret.json"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -91,10 +91,10 @@ spec:
           configMap:
             name: {{ include "n8n.fullname" . }}
         {{- end }}
-        {{- if .Values.secret }}
+        {{- if or (.Values.secret) (.Values.existingSecret) }}
         - name: secret-volume
           secret:
-            secretName: {{ include "n8n.fullname" . }}
+            secretName: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ include "n8n.fullname" . }}{{ end }}
             items:
               - key: "secret.json"
                 path: "secret.json"

--- a/values.yaml
+++ b/values.yaml
@@ -9,7 +9,7 @@ config:
     pruneData: "true" # prune executions by default
     pruneDataMaxAge: 3760 # Per defaut we store 1 year of history
 
-    
+# existingSecret: "" # Use an existing Kubernetes secret, e.g created by hand or Vault operator.
 secret: # Dict with all n8n json config options, unlike config the values here will end up in a secret.
 
 # Typical Example of a config in combination with a secret.

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,7 @@ config:
     pruneData: "true" # prune executions by default
     pruneDataMaxAge: 3760 # Per defaut we store 1 year of history
 
+# existingSecret and secret are exclusive, with existingSecret taking priority.
 # existingSecret: "" # Use an existing Kubernetes secret, e.g created by hand or Vault operator.
 secret: # Dict with all n8n json config options, unlike config the values here will end up in a secret.
 


### PR DESCRIPTION
It's typically bad practice to submit secrets to Git repositories, but this chart appears to encourage it. This PR adds the ability to specify an existing secret created by another source (e.g the Vault operator, manually) to avoid needing to add the secrets to the value file, which may be committed to git.