### PR TITLE
feat: add probes and initcontainers + app upgrade

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
-version: 0.10.0
-appVersion: 0.236.3
+version: 0.12.0
+appVersion: 1.5.1
 type: application
 
 description: "A Kubernetes Helm chart for n8n a free and open fair-code licensed node based Workflow Automation Tool. Easily automate tasks across different services."
@@ -29,9 +29,13 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
+      description: "Updated App Version to 1.5.1"
+    - kind: added
+      description: "Added support for specifying initContainers and probes"
+    - kind: changed
       description: "Updated App Version to 0.236.3"
     - kind: added
       description: "Support Kubernetes 1.25"
       links:
         - name: GitHub PR
-          url: https://github.com/8gears/n8n-helm-chart/pull/46          
+          url: https://github.com/8gears/n8n-helm-chart/pull/46

--- a/templates/deployment.webhooks.yaml
+++ b/templates/deployment.webhooks.yaml
@@ -37,6 +37,10 @@ spec:
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+      {{ tpl (toYaml .Values.initContainers) . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/templates/deployment.worker.yaml
+++ b/templates/deployment.worker.yaml
@@ -37,6 +37,10 @@ spec:
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+      {{ tpl (toYaml .Values.initContainers) . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.initContainers }}
+      initContainers:
+      {{ tpl (toYaml .Values.initContainers) . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.command }}
@@ -54,14 +58,14 @@ spec:
             - name: http
               containerPort: {{ get .Values.config "port" | default 5678 }}
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            httpGet:
-              path: /healthz
-              port: http
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/values.yaml
+++ b/values.yaml
@@ -4,7 +4,7 @@ n8n:
   encryption_key: # n8n creates a random encryption key automatically on the first launch and saves it in the ~/.n8n folder. That key is used to encrypt the credentials before they get saved to the database.
 defaults:
 
-config: 
+config:
   executions:
     pruneData: "true" # prune executions by default
     pruneDataMaxAge: 3760 # Per defaut we store 1 year of history
@@ -214,11 +214,40 @@ command: []
 #  - -c
 #  - chmod o+rx /root; chown -R node /root/.n8n || true; chown -R node /root/.n8n; ln -s /root/.n8n /home/node; chown -R node /home/node || true; node /usr/local/bin/n8n
 
+# here you can override the livenessProbe for the main container
+# it may be used to increase the timeout for the livenessProbe (e.g. to resolve issues like
+
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  # initialDelaySeconds: 30
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 6
+  # successThreshold: 1
+
+# here you can override the readinessProbe for the main container
+# it may be used to increase the timeout for the readinessProbe (e.g. to resolve issues like
+
+readinessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  # initialDelaySeconds: 30
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 6
+  # successThreshold: 1
+
+# here you can add init containers to the various deployments
+initContainers: []
+
 service:
   type: ClusterIP
   port: 80
   annotations: {}
-    
+
 ingress:
   enabled: false
   annotations: {}
@@ -231,7 +260,7 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
-  
+
   # define a custom incressClassName, like "traefik" or "nginx"
   className: ""
 
@@ -269,7 +298,7 @@ affinity: {}
 
 scaling:
   enabled: false
-  
+
   worker:
     count: 2
     concurrency: 2
@@ -280,7 +309,7 @@ scaling:
     count: 1
 
   redis:
-    host: 
+    host:
     password:
 
 
@@ -294,4 +323,4 @@ redis:
     persistence:
       enabled: true
       existingClaim: ""
-      size: 2Gi  
+      size: 2Gi


### PR DESCRIPTION
Closes: https://github.com/8gears/n8n-helm-chart/issues/38

This PR adds the ability to configure the readiness and liveness probes of the container. It also allows for adding init containers to all the deployments. Lastly, it bumps n8n to the latest version and adds some comments so Artifacthub will pick up the change and publish a new version of the chart.