### PR TITLE
fixed secret volume mnt for existing secret

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
             - name: config-volume
               mountPath: /n8n-config
             {{- end }}
-            {{- if .Values.secret }}
+            {{- if or (.Values.secret) (.Values.existingSecret) }}
             - name: secret-volume
               mountPath: /n8n-secret
                 {{- end }}


### PR DESCRIPTION
Hello together,
if you use an existingSecret to set your n8n configuration variables, the volume gets specified in the volumes section of the deployment:
`{{- if or (.Values.secret) (.Values.existingSecret) }}
        - name: secret-volume
          secret:
            secretName: {{ if .Values.existingSecret }}{{ .Values.existingSecret }}{{ else }}{{ include "n8n.fullname" . }}{{ end }}
            items:
              - key: "secret.json"
                path: "secret.json"
        {{- end }}`

but it doesn't get mounted because of:

`{{- if .Values.secret }}
            - name: secret-volume
              mountPath: /n8n-secret
                {{- end }}`

I think the mount should be created if secret or existing secret is specified. What do you think?