### PR TITLE
added missing ingress routes for webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ endpoints:
   rest:             # Path for rest endpoint  default: rest
   webhook:          # Path for webhook endpoint  default: webhook
   webhookTest:      # Path for test-webhook endpoint  default: webhook-test
+  webhookWaiting:   # Path for test-webhook endpoint  default: webhook-waiting
 externalHookFiles:  # Files containing external hooks. Multiple files can be separated by colon - default: ''
 nodes:
   exclude:          # Nodes not to load - default: "[]"

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -60,6 +60,20 @@ spec:
                 name: {{ $fullName }}-webhooks
                 port:
                   number: {{ $svcPort }}
+          - path: {{ . }}webhook-test/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-webhooks
+                port:
+                  number: {{ $svcPort }}
+          - path: {{ . }}webhook-waiting/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-webhooks
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
           {{- end }}
     {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -92,6 +92,7 @@ secret: # Dict with all n8n json config options, unlike config the values here w
 #  rest:       # Path for rest endpoint  default: rest
 #  webhook:    # Path for webhook endpoint  default: webhook
 #  webhookTest: # Path for test-webhook endpoint  default: webhook-test
+#  webhookWaiting: # Path for waiting-webhook endpoint  default: webhook-waiting
 #externalHookFiles: # Files containing external hooks. Multiple files can be separated by colon - default: ''
 #nodes:
 #  exclude: # Nodes not to load - default: "[]"


### PR DESCRIPTION
The following paths where missing in ingress:

- webhook-test/
- webhook-waiting/

For some strange reasons the `webhook-test` was routed to the main pods (not the webhook pods) and it worked.

The `webhook-waiting` route will give the /index.html.

