### PR TITLE
fix: set $sec_val if existingSecret is set

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -117,7 +117,7 @@ Create the name of the service account to use
     {{- if .Values.config }}
         {{- $conf_val = "/n8n-config/config.json" }}
     {{- end }}
-    {{- if .Values.secret }}
+    {{- if or .Values.secret .Values.existingSecret }}
         {{- $sec_val = "/n8n-secret/secret.json" }}
     {{- end }}
     {{- if and .Values.config .Values.secret }}


### PR DESCRIPTION
When using `existingSecret` the path to the file was not added to `n8n.configFiles` in the helpers.