### PR TITLE
fix: missing volume mount for existingSecret

### DIFF
--- a/templates/deployment.worker.yaml
+++ b/templates/deployment.worker.yaml
@@ -69,7 +69,7 @@ spec:
             - name: config-volume
               mountPath: /n8n-config
             {{- end }}
-            {{- if .Values.secret }}
+            {{- if or (.Values.secret) (.Values.existingSecret) }}
             - name: secret-volume
               mountPath: /n8n-secret
                 {{- end }}


### PR DESCRIPTION
Fixes the missing volume mount for secrets when `existingSecret` is set.