### PR TITLE
Support existingSecret for redis configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ scaling:
     host:
     password:
     existingSecret:
-    existingSecretKey:
+    existingSecretPasswordKey:
 
 redis:
   enabled: false

--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ scaling:
   redis:
     host:
     password:
+    existingSecret:
+    existingSecretKey:
 
 redis:
   enabled: false

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -92,6 +92,13 @@ Selector labels
 - name: "QUEUE_BULL_REDIS_PASSWORD"
   value: "{{ .Values.scaling.redis.password }}"
 {{ end }}
+{{- if and .Values.scaling.redis.existingSecret .Values.scaling.redis.existingSecretKey }}
+- name: "QUEUE_BULL_REDIS_PASSWORD"
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.scaling.redis.existingSecret }}
+      key: {{ .Values.scaling.redis.existingSecretKey }}
+{{ end }}
 {{- if .Values.scaling.webhook.enabled }}
 - name: "N8N_DISABLE_PRODUCTION_MAIN_PROCESS"
   value: "true"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -92,12 +92,12 @@ Selector labels
 - name: "QUEUE_BULL_REDIS_PASSWORD"
   value: "{{ .Values.scaling.redis.password }}"
 {{ end }}
-{{- if and .Values.scaling.redis.existingSecret .Values.scaling.redis.existingSecretKey }}
+{{- if and .Values.scaling.redis.existingSecret .Values.scaling.redis.existingSecretPasswordKey }}
 - name: "QUEUE_BULL_REDIS_PASSWORD"
   valueFrom:
     secretKeyRef:
       name: {{ .Values.scaling.redis.existingSecret }}
-      key: {{ .Values.scaling.redis.existingSecretKey }}
+      key: {{ .Values.scaling.redis.existingSecretPasswordKey }}
 {{ end }}
 {{- if .Values.scaling.webhook.enabled }}
 - name: "N8N_DISABLE_PRODUCTION_MAIN_PROCESS"

--- a/values.yaml
+++ b/values.yaml
@@ -321,8 +321,8 @@ scaling:
   redis:
     host:
     password:
-    existingSecret:
-    existingSecretPasswordKey:
+    # existingSecret:
+    # existingSecretPasswordKey:
 
 
 ## Bitnami Redis configuration

--- a/values.yaml
+++ b/values.yaml
@@ -322,7 +322,7 @@ scaling:
     host:
     password:
     existingSecret:
-    existingSecretKey:
+    existingSecretPasswordKey:
 
 
 ## Bitnami Redis configuration

--- a/values.yaml
+++ b/values.yaml
@@ -321,6 +321,8 @@ scaling:
   redis:
     host:
     password:
+    existingSecret:
+    existingSecretKey:
 
 
 ## Bitnami Redis configuration


### PR DESCRIPTION
Introduces scaling.redis.existingSecret and scaling.redis.existingSecretKey to enable referencing an existing secret containing the Redis password. This aligns with the Bitnami Redis chart, allowing both to use the same secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration options that allow users to integrate existing Kubernetes secrets for Redis, providing enhanced flexibility and improved security for managing credentials.
- **Documentation**
	- Updated the guidance to help users understand how to enable these new configuration options in their deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->