### PR TITLE
feat: init-container when using dynamic persistence

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 0.22.0
+version: 0.23.0
 appVersion: 1.30.0
 type: application
 
@@ -33,4 +33,9 @@ annotations:
       description: "Apply Security Context to all Pods"
       links:
         - name: "Related GitHub Issue"
-            url: https://github.com/8gears/n8n-helm-chart/issues/71         
+          url: https://github.com/8gears/n8n-helm-chart/issues/71
+    - kind: fixed
+      description: "Fixed issue with dynamic volumes not having the correct directories laid out"
+      links:
+        - name: "Related GitHub Issue"
+          url: https://github.com/8gears/n8n-helm-chart/issues/71

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -29,11 +29,6 @@ annotations:
   artifacthub.io/prerelease: "true"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed 
-      description: "Apply Security Context to all Pods"
-      links:
-        - name: "Related GitHub Issue"
-          url: https://github.com/8gears/n8n-helm-chart/issues/71
     - kind: fixed
       description: "Fixed issue with dynamic volumes not having the correct directories laid out"
       links:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
       initContainers:
       {{- if and .Values.persistence.enabled (eq .Values.persistence.type "dynamic") }}
       - name: init-data-dir
-        image: busybox:1.31.1
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
         command: ["/bin/sh", "-c", "mkdir -p /home/node/.n8n/"]
         volumeMounts:
         - name: data

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -41,9 +41,19 @@ spec:
       serviceAccountName: {{ include "n8n.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.initContainers }}
+      {{- if or .Values.initContainers (and .Values.persistence.enabled (eq .Values.persistence.type "dynamic")) }}
       initContainers:
+      {{- if and .Values.persistence.enabled (eq .Values.persistence.type "dynamic") }}
+      - name: init-data-dir
+        image: busybox:1.31.1
+        command: ["/bin/sh", "-c", "mkdir -p /home/node/.n8n/"]
+        volumeMounts:
+        - name: data
+          mountPath: /home/node/.n8n
+      {{- end }}
+      {{- if .Values.initContainers }}
       {{ tpl (toYaml .Values.initContainers) . | nindent 8 }}
+      {{- end }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}


### PR DESCRIPTION
Hi,

This is my first time contributing to a helm chart so I may have missed some parts.

I've tested this change with the following helmfile

```yml
releases:
  - name: n8n-test
    namespace: n8n-test
    chart: ./n8n-0.23.0.tgz
    values:
      - persistence:
          enabled: true
          type: dynamic
          storageClass: "standard"
          size: 10Gi
```

And ran `helm lint`.

Let me know if I'm missing something, happy to fix.

Closes #71 