### PR TITLE
Fix persistence init container indentation

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,12 +44,12 @@ spec:
       {{- if or .Values.initContainers (and .Values.persistence.enabled (eq .Values.persistence.type "dynamic")) }}
       initContainers:
       {{- if and .Values.persistence.enabled (eq .Values.persistence.type "dynamic") }}
-      - name: init-data-dir
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-        command: ["/bin/sh", "-c", "mkdir -p /home/node/.n8n/"]
-        volumeMounts:
-        - name: data
-          mountPath: /home/node/.n8n
+        - name: init-data-dir
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          command: ["/bin/sh", "-c", "mkdir -p /home/node/.n8n/"]
+          volumeMounts:
+            - name: data
+              mountPath: /home/node/.n8n
       {{- end }}
       {{- if .Values.initContainers }}
       {{ tpl (toYaml .Values.initContainers) . | nindent 8 }}


### PR DESCRIPTION
Observed on `master` and Helm Chart version `0.23.0`

Indentation for the newly introduced `init-data-dir` init container (#82) is incorrect, resulting in Helm templating errors when setting and making use of `.Values.initContainers`:

values.yaml:
```
initContainers:
  - name: wait-for-postgres
    image: ghcr.io/patrickdappollonio/wait-for:v1.0.0
    env:
    - name: POSTGRES_ADDRESS
      value: "postgresql:5432"
    command:
      - /wait-for
    args:
      - --host="$(POSTGRES_ADDRESS)"
      - --timeout=240s
      - --verbose
```

Rendered Helm Deployment:
```
[...]
      initContainers:
      - name: init-data-dir
        image: "n8nio/n8n:1.33.1"
        command: ["/bin/sh", "-c", "mkdir -p /home/node/.n8n/"]
        volumeMounts:
        - name: data
          mountPath: /home/node/.n8n
      
        - args:
          - --host="$(POSTGRES_ADDRESS)"
          - --timeout=240s
          - --verbose
          command:
          - /wait-for
          env:
          - name: POSTGRES_ADDRESS
            value: postgresql:5432
          image: ghcr.io/patrickdappollonio/wait-for:v1.0.0
          name: wait-for-postgres
[...]
```

Observed error:
```
error validating data: [ValidationError(Deployment.spec.template.spec.initContainers[0].volumeMounts[1]): unknown field "args" in io.k8s.api.core.v1.VolumeMount, ValidationError(Deployment.spec.template.spec.initContainers[0].volumeMounts[1]): unknown field "command" in io.k8s.api.core.v1.VolumeMount, ValidationError(Deployment.spec.template.spec.initContainers[0].volumeMounts[1]): unknown field "env" in io.k8s.api.core.v1.VolumeMount, ValidationError(Deployment.spec.template.spec.initContainers[0].volumeMounts[1]): unknown field "image" in io.k8s.api.core.v1.VolumeMount, ValidationError(Deployment.spec.template.spec.initContainers[0].volumeMounts[1]): missing required field "mountPath" in io.k8s.api.core.v1.VolumeMount]
```

As you can see, due to the wrong indentation, the additional configured init container is not treated as such but as additional volume mount for the `init-data-dir` init container.