### PR TITLE
fix(ingress): change webhook-test endpoint

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -64,7 +64,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName }}-webhooks
+                name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
           - path: {{ . }}webhook-waiting/


### PR DESCRIPTION
It seems that webhook-test are implemented only in the master