### PR TITLE
add `/form` ingress path

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
 version: 0.23.0
-appVersion: 1.33.1
+appVersion: 1.33.2
 type: application
 
 description: "A Kubernetes Helm chart for n8n a free and open fair-code licensed node based Workflow Automation Tool. Easily automate tasks across different services."

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -74,6 +74,13 @@ spec:
                 name: {{ $fullName }}-webhooks
                 port:
                   number: {{ $svcPort }}
+          - path: {{ . }}form/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}-webhooks
+                port:
+                  number: {{ $svcPort }}
           {{- end }}
           {{- end }}
     {{- end }}


### PR DESCRIPTION
Solves https://github.com/8gears/n8n-helm-chart/issues/92

form-test is still located on the main process as it is not working on the webhook pods.