### PR TITLE
Fix: OCI registry when releasing helm chart

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -37,4 +37,4 @@ jobs:
       - name: Push charts to 8gears.container-registry.com
         run: |                                                  
           package_path=$(helm package charts/n8n --dependency-update | grep -o '/.*\.tgz')
-          helm push "${package_path}" "oci://8gears.container-registry.com/library/n8n"
+          helm push "${package_path}" "oci://8gears.container-registry.com/library"


### PR DESCRIPTION
Installation of helm chart use this path in the OCI registry: `oci://8gears.container-registry.com/library/n8n` but with latest release it is required to add an extra path `/n8n`

When trying:
```
helm pull oci://8gears.container-registry.com/library/n8n --version 0.24.0
Error: 8gears.container-registry.com/library/n8n:0.24.0: not found
```

it works when
```
helm pull oci://8gears.container-registry.com/library/n8n/n8n --version 0.24.0
```

But that's not the path used in the helm chart documentation. CF: https://artifacthub.io/packages/helm/open-8gears/n8n/

You can also confirm that latest release `0.24.0` is not available in the helm chart. CF: https://artifacthub.io/packages/helm/open-8gears/n8n/?modal=changelog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Helm chart push configuration to a new location within the container registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->