### PR TITLE
feat: add envfrom into deployments to enable loading entire secrets or configMaps into container ENV_VARs

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,12 @@ extraEnv: { }
 # Set this if running behind a reverse proxy and the external port is different from the port n8n runs on
 #   WEBHOOK_TUNNEL_URL: "https://n8n.myhost.com/
 
+# Set additional environment variables on the Deployment from k8s secrets
+envFrom: []
+# List of existing secrets to add to deployments
+# - secretRef:
+#     name: secret-name
+
 replicaCount: 1
 
 image:

--- a/README.md
+++ b/README.md
@@ -195,8 +195,10 @@ extraEnv: { }
 # Set additional environment variables on the Deployment from k8s secrets
 envFrom: []
 # List of existing secrets to add to deployments
-# - secretRef:
-#     name: secret-name
+# Example using envFrom with AWS SSM ParameterStore via ExternalSecrets:
+# envFrom:
+#   - secretRef:
+#       name: secret-name
 
 replicaCount: 1
 

--- a/charts/n8n/templates/deployment.webhooks.yaml
+++ b/charts/n8n/templates/deployment.webhooks.yaml
@@ -56,6 +56,10 @@ spec:
           args: ["webhook"]
           env:
             {{- include "n8n.deploymentPodEnvironments" . | nindent 12 }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ get .Values.config "port" | default 5678 }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -56,6 +56,10 @@ spec:
           args: ["worker", "--concurrency={{ .Values.scaling.worker.concurrency }}"]
           env:
             {{- include "n8n.deploymentPodEnvironments" . | nindent 12 }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ get .Values.config "port" | default 5678 }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             {{- include "n8n.deploymentPodEnvironments" . | nindent 12 }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           lifecycle:
             {{- toYaml .Values.lifecycle | nindent 12 }}
           ports:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -116,6 +116,10 @@ extraEnvSecrets: {}
 #     name: postgres-user-auth
 #     key: password
 
+envFrom: []
+  # - secretRef:
+  #     name: secret-name
+
 ## Common Kubernetes Config Settings
 persistence:
   ## If true, use a Persistent Volume Claim, If false, use emptyDir


### PR DESCRIPTION
## feat: add envFrom into deployments to enable loading entire secrets or configMaps into container ENV_VARs

Scenario:

I use ExternalSecrets to fetch ENV_VARs from AWS SSM ParameterStore and create k8s secrets. Using envFrom is possible to load the entire secret without mapping key by key. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a section inviting community involvement, encouraging contributions and collaboration.
  - Enhanced documentation with clearer guidance on configuration and installation, including specific YAML examples for typical setups.
  - Added a new section titled `Typical Values Example` to provide practical configuration insights.

- **Chores**
  - Updated the `Requirements`, `Configuration`, `Installation`, `N8N Specific Config`, `Values`, and `Scaling` sections for improved clarity and usability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->