### PR TITLE
fix: test webhook

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 0.24.4
+version: 0.24.5
 appVersion: 1.49.0
 type: application
 description: "A Kubernetes Helm chart for n8n a free and open fair-code licensed node based Workflow Automation Tool. Easily automate tasks across different services."

--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -64,7 +64,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName }}-webhooks
+                name: {{ $fullName }}
                 port:
                   number: {{ $svcPort }}
           - path: {{ . }}webhook-waiting/


### PR DESCRIPTION
#86 

This PR fixes the issue with `webhook-test` endpoint by pointing it to the main n8n service instead of webhooks service.

