### PR TITLE
✨ feat: worker and webhook autosacling

### DIFF
--- a/charts/n8n/templates/deployment.webhooks.yaml
+++ b/charts/n8n/templates/deployment.webhooks.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not .Values.webhookAutoscaling.enabled }}
   replicas: {{ .Values.scaling.webhook.count }}
   {{- end }}
   strategy:

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
+  {{- if not .Values.workerAutoscaling.enabled }}
   replicas: {{ .Values.scaling.worker.count }}
   {{- end }}
   strategy:

--- a/charts/n8n/templates/hpa.webhook.yaml
+++ b/charts/n8n/templates/hpa.webhook.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.scaling.enabled }}
+{{- if .Values.webhookAutoscaling.enabled }}
 {{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}
@@ -47,5 +48,6 @@ spec:
         name: memory
         targetAverageUtilization: {{ .Values.webhookAutoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/n8n/templates/hpa.webhook.yaml
+++ b/charts/n8n/templates/hpa.webhook.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
+apiVersion: autoscaling/v2beta1
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "n8n.fullname" . }}-webhook
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "n8n.fullname" . }}-webhook
+  minReplicas: {{ .Values.webhookAutoscaling.minReplicas }}
+  maxReplicas: {{ .Values.webhookAutoscaling.maxReplicas }}
+  metrics:
+{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
+    {{- if .Values.webhookAutoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.webhookAutoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.webhookAutoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.webhookAutoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- else -}}
+    {{- if .Values.webhookAutoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.webhookAutoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.webhookAutoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.webhookAutoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/n8n/templates/hpa.worker.yaml
+++ b/charts/n8n/templates/hpa.worker.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.autoscaling.enabled }}
+{{- if .Values.scaling.enabled }}
+{{- if .Values.workerAutoscaling.enabled }}
 {{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: autoscaling/v2
 {{- else -}}
@@ -47,5 +48,6 @@ spec:
         name: memory
         targetAverageUtilization: {{ .Values.workerAutoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/n8n/templates/hpa.worker.yaml
+++ b/charts/n8n/templates/hpa.worker.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.autoscaling.enabled }}
+{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: autoscaling/v2
+{{- else -}}
+apiVersion: autoscaling/v2beta1
+{{- end }}
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "n8n.fullname" . }}-worker
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "n8n.fullname" . }}-worker
+  minReplicas: {{ .Values.workerAutoscaling.minReplicas }}
+  maxReplicas: {{ .Values.workerAutoscaling.maxReplicas }}
+  metrics:
+{{- if semverCompare ">=1.25-0" .Capabilities.KubeVersion.GitVersion -}}
+    {{- if .Values.workerAutoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.workerAutoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.workerAutoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.workerAutoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- else -}}
+    {{- if .Values.workerAutoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.workerAutoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.workerAutoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.workerAutoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -277,8 +277,23 @@ ingress:
 workerResources:
   {}
 
+workerAutoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
 webhookResources:
   {}
+
+webhookAutoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
 
 resources:
   {}


### PR DESCRIPTION
By adding `webhookAutoscaling` and `workerAutoscaling`

HPA will work for webhook and worker also fixes the problem where when autoscaling is enabled replicaCount will not work for webhook and worker

closes #80
closes #87

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced Horizontal Pod Autoscaler (HPA) configurations for both webhook and worker components, enabling automated scaling based on resource utilization.
  - Added granular autoscaling settings in the configuration file for improved resource management.

- **Bug Fixes**
  - Adjusted conditions for autoscaling checks to ensure correct scaling behavior for webhooks and workers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->