### PR TITLE
feat: add support for deployment annotations and labels

### DIFF
--- a/charts/n8n/templates/deployment.webhooks.yaml
+++ b/charts/n8n/templates/deployment.webhooks.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "n8n.fullname" . }}-webhook
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+    {{- if .Values.deploymentLabels }}
+    {{- toYaml .Values.deploymentLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.scaling.webhook.count }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "n8n.fullname" . }}-worker
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+    {{- if .Values.deploymentLabels }}
+    {{- toYaml .Values.deploymentLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.scaling.worker.count }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+    {{- if .Values.deploymentLabels }}
+    {{- toYaml .Values.deploymentLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -177,6 +177,18 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# Annotations to be implemented on Deployment
+deploymentAnnotations: {}
+  # example:
+  # notification.monitor.io/slack: "true"
+  # fluxcd.io/automated: "true"
+
+# Labels to be implemented on Deployment
+deploymentLabels: {}
+  # example:
+  # environment: production
+  # team: platform
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
# Add support for custom deployment annotations and labels

## Description

This PR adds support for custom annotations and labels at the deployment level. Previously, the chart only supported pod-level annotations and labels. This enhancement allows users to add Kubernetes annotations and labels specifically at the deployment level, which is useful for various deployment management and integration scenarios.

### Changes Made

- Added new `deploymentAnnotations` and `deploymentLabels` fields in values.yaml
- Updated all deployment manifests (main, webhook, and worker) to support the new fields
- Maintained backwards compatibility by making the new fields optional
- Kept existing pod-level annotations and labels functionality unchanged

### Example Usage

```yaml
# values.yaml or values override
deploymentAnnotations:
  fluxcd.io/automated: "true"
  notification.monitor.io/slack: "true"

deploymentLabels:
  environment: production
  team: platform
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for custom deployment annotations and labels in the Helm chart
	- Enabled flexible configuration of metadata for n8n Kubernetes deployments

- **Improvements**
	- Enhanced deployment configuration with optional label and annotation customization
	- Improved deployment resource metadata management through Helm values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->