### PR TITLE
fix: Add default port when undefined

### DIFF
--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -66,7 +66,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ get .Values.webhook.config "port" | default 5678 }}
+              containerPort: {{ get (default (dict) .Values.webhook.config) "port" | default 5678 }}
               protocol: TCP
           {{- with .Values.webhook.livenessProbe }}
           livenessProbe:

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -68,7 +68,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: {{ get .Values.worker.config "port" | default 5678 }}
+              containerPort: {{ get (default (dict) .Values.worker.config) "port" | default 5678 }}
               protocol: TCP
           {{- with .Values.main.livenessProbe }}
           livenessProbe:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             - secretRef:
                 name: app-secret-{{ include "n8n.fullname" . }}
             {{- end }}
-          env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}  
+          env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.main.extraEnv }}
             - name: {{ $key }}
               {{- toYaml $value | nindent 14 }}
@@ -74,7 +74,7 @@ spec:
             {{- toYaml .Values.main.lifecycle | nindent 12 }}
           ports:
             - name: http
-              containerPort: {{ get .Values.main.config "port" | default 5678 }}
+              containerPort: {{ get (default (dict) .Values.main.config) "port" | default 5678 }}
               protocol: TCP
           {{- with .Values.main.livenessProbe }}
           livenessProbe:


### PR DESCRIPTION
fixes error if no port is defined in .Values.worker.config and .Values.webhook.config, e.g.

```
Error: template: n8n/templates/deployment.worker.yaml:71:43: executing "n8n/templates/deployment.worker.yaml" at <.Values.worker.config>: wrong type for value; expected map[string]interface {}; got interface {}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced deployment configurations to safely handle missing settings and ensure robust default behavior.
	- Improved environment variable formatting for consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->