### PR TITLE
feat: Add environment settings to worker deployment

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.1
+version: 1.1.0
 appVersion: 1.76.1
 type: application
 description: "A Kubernetes Helm chart for n8n a free and open fair-code licensed node based Workflow Automation Tool. Easily automate tasks across different services."
@@ -34,4 +34,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Add default port to worker, deployment and webhook when undefined"
+      description: "Add environment settings to worker deployment"

--- a/charts/n8n/templates/configmap.worker.yaml
+++ b/charts/n8n/templates/configmap.worker.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.worker.config }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: worker-config-{{ include "n8n.fullname" . }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+data:
+  {{- include "toEnvVars" (dict "values" .Values.worker.config "prefix" "") | nindent 2 }}
+{{- end }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -52,6 +52,28 @@ spec:
             {{- toYaml .Values.worker.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            {{- if .Values.main.config }}
+            - configMapRef:
+                name: app-config-{{ include "n8n.fullname" . }}
+            {{- end }}
+           {{- if .Values.main.secret }}
+            - secretRef:
+                name: app-secret-{{ include "n8n.fullname" . }}
+            {{- end }}
+            {{- if .Values.worker.config }}
+            - configMapRef:
+                name: worker-config-{{ include "n8n.fullname" . }}
+            {{- end }}
+           {{- if .Values.worker.secret }}
+            - secretRef:
+                name: worker-secret-{{ include "n8n.fullname" . }}
+            {{- end }}
+          env: {{ not (empty .Values.worker.extraEnv) | ternary nil "[]" }}
+            {{- range $key, $value := .Values.worker.extraEnv }}
+            - name: {{ $key }}
+              {{- toYaml $value | nindent 14 }}
+            {{- end }}
           {{- if .Values.worker.command }}
           command:
             {{- toYaml .Values.worker.command | nindent 12 }}

--- a/charts/n8n/templates/secret.worker.yaml
+++ b/charts/n8n/templates/secret.worker.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.worker.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: worker-secret-{{ include "n8n.fullname" . }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- include "toEnvVars" (dict "values" .Values.worker.secret "prefix" "" "isSecret" true) | nindent 4 }}
+
+{{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -260,6 +260,18 @@ main:
 #
 worker:
   enabled: false
+
+  # additional (to main) config for worker
+  config: {}
+
+  # additional (to main) config for worker
+  secret: {}
+
+  # Extra environmental variables, so you can reference other configmaps and secrets into n8n as env vars.
+  extraEnv: {}
+  #   WEBHOOK_URL:
+  #   value: "http://webhook.domain.tld"
+
   count: 2
   # You can define the number of jobs a worker can run in parallel by using the concurrency flag. It defaults to 10. To change it:
   concurrency: 10


### PR DESCRIPTION
Would be nice to be able to set N8N_ENCRYPTION_KEY and other settings in worker as right now it is not possible and not possible to run workers at all, this could fix the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced worker deployment flexibility with new options for custom configuration, environment variables, and secret management.

- **Chores**
  - Upgraded the Helm chart to version 1.1.0 with refined descriptive annotations for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->