### PR TITLE
feat: add support for custom deployment annotations and labels

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.1.0
+version: 1.2.0
 appVersion: 1.76.1
 type: application
 description: "A Kubernetes Helm chart for n8n a free and open fair-code licensed node based Workflow Automation Tool. Easily automate tasks across different services."
@@ -34,4 +34,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Add environment settings to worker deployment"
+      description: "Add support to add custom deployment annotations and labels"

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -7,6 +7,13 @@ metadata:
   name: {{ include "n8n.fullname" . }}-webhook
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+    {{- if .Values.webhook.deploymentLabels }}
+    {{- toYaml .Values.webhook.deploymentLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.webhook.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.webhook.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.webhook.autoscaling.enabled }}
   replicas: {{ .Values.webhook.replicaCount }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "n8n.fullname" . }}-worker
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+    {{- if .Values.worker.deploymentLabels }}
+    {{- toYaml .Values.worker.deploymentLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.worker.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.worker.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.worker.autoscaling.enabled }}
   replicas: {{ .Values.worker.count }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -4,6 +4,13 @@ metadata:
   name: {{ include "n8n.fullname" . }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
+    {{- if .Values.main.deploymentLabels }}
+    {{- toYaml .Values.main.deploymentLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.main.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.main.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.main.autoscaling.enabled }}
   replicas: {{ .Values.main.replicaCount }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -146,7 +146,13 @@ main:
     # If not set and create is true, a name is generated using the fullname template
     name: ""
 
+  # Annotations to be implemented on the main service deployment
+  deploymentAnnotations: {}
+  # Labels to be implemented on the main service deployment
+  deploymentLabels: {}
+  # Annotations to be implemented on the main service pod
   podAnnotations: {}
+  # Labels to be implemented on the main service pod
   podLabels: {}
 
   podSecurityContext:
@@ -331,8 +337,13 @@ worker:
     # If not set and create is true, a name is generated using the fullname template
     name: ""
 
+  # Annotations to be implemented on the worker deployment
+  deploymentAnnotations: {}
+  # Labels to be implemented on the worker deployment
+  deploymentLabels: {}
+  # Annotations to be implemented on the worker pod
   podAnnotations: {}
-
+  # Labels to be implemented on the worker pod
   podLabels: {}
 
   podSecurityContext:
@@ -513,8 +524,13 @@ webhook:
     # If not set and create is true, a name is generated using the fullname template
     name: ""
 
+  # Annotations to be implemented on the webhook deployment
+  deploymentAnnotations: {}
+  # Labels to be implemented on the webhook deployment
+  deploymentLabels: {}
+  # Annotations to be implemented on the webhook pod
   podAnnotations: {}
-
+  # Labels to be implemented on the webhook pod
   podLabels: {}
 
   podSecurityContext:


### PR DESCRIPTION
# Add support for custom deployment annotations and labels

## Description

This PR is a follow up of the [previously raised PR](https://github.com/8gears/n8n-helm-chart/pull/129), it adds support for custom annotations and labels at the deployment level. Previously, the chart only supported pod-level annotations and labels. This enhancement allows users to add Kubernetes annotations and labels specifically at the deployment level, which is useful for various deployment management and integration scenarios.

### Changes Made

- Added new `deploymentAnnotations` and `deploymentLabels` fields on each component (main. worker, webhook) in values.yaml
- Updated all deployment manifests (main, webhook, and worker) to support the new fields
- Maintained backwards compatibility by making the new fields optional
- Kept existing pod-level annotations and labels functionality unchanged

### Example Usage

```yaml
# values.yaml or values override
main:
  deploymentAnnotations:
    fluxcd.io/automated: "true"
    notification.monitor.io/slack: "true"
  
  deploymentLabels:
    environment: production
    team: platform
    component: n8n

worker:
  deploymentAnnotations:
    fluxcd.io/automated: "true"
    notification.monitor.io/slack: "true"
  
  deploymentLabels:
    environment: production
    team: platform
    component: n8n-worker

webhook:
  deploymentAnnotations:
    fluxcd.io/automated: "true"
    notification.monitor.io/slack: "true"
  
  deploymentLabels:
    environment: production
    team: platform
    component: n8n-webhook
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options for custom annotations and labels across deployments and pods, enhancing flexibility for managing metadata in your Kubernetes environment.
- **Chores**
  - Updated the system version from 1.1.0 to 1.2.0 and refreshed descriptive text to reflect the new configuration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->