### PR TITLE
Use fullname as prefix instead of suffix

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.3
+version: 1.0.4
 appVersion: 1.81.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,7 +34,5 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "fixed helm upgrade requires valkey.password 1.0.0-beta2 -> 1.0.2"
     - kind: changed
-      description: "update valkey dependency to chart version 2.4.2 and app version 8.0.2"
+      description: "use fullname as prefix instead of suffix"

--- a/charts/n8n/templates/configmap.webhook.yaml
+++ b/charts/n8n/templates/configmap.webhook.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: webhook-config-{{ include "n8n.fullname" . }}
+  name: {{ include "n8n.fullname" . }}-webhook-config
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 data:

--- a/charts/n8n/templates/configmap.worker.yaml
+++ b/charts/n8n/templates/configmap.worker.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: worker-config-{{ include "n8n.fullname" . }}
+  name: {{ include "n8n.fullname" . }}-worker-config
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 data:

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: app-config-{{ include "n8n.fullname" . }}
+  name: {{ include "n8n.fullname" . }}-app-config
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 data:

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -86,19 +86,19 @@ spec:
           envFrom:
             {{- if .Values.main.config }}
             - configMapRef:
-                name: app-config-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-app-config
             {{- end }}
            {{- if .Values.main.secret }}
             - secretRef:
-                name: app-secret-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-app-secret
             {{- end }}
             {{- if .Values.webhook.config }}
             - configMapRef:
-                name: webhook-config-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-webhook-config
             {{- end }}
            {{- if .Values.webhook.secret }}
             - secretRef:
-                name: webhook-secret-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-webhook-secret
             {{- end }}
 
           env: {{ not (empty .Values.webhook.extraEnv) | ternary nil "[]" }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -61,19 +61,19 @@ spec:
           envFrom:
             {{- if .Values.main.config }}
             - configMapRef:
-                name: app-config-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-app-config
             {{- end }}
            {{- if .Values.main.secret }}
             - secretRef:
-                name: app-secret-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-app-secret
             {{- end }}
             {{- if .Values.worker.config }}
             - configMapRef:
-                name: worker-config-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-worker-config
             {{- end }}
            {{- if .Values.worker.secret }}
             - secretRef:
-                name: worker-secret-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-worker-secret
             {{- end }}
           env: {{ not (empty .Values.worker.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.worker.extraEnv }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -66,11 +66,11 @@ spec:
           envFrom:
             {{- if .Values.main.config }}
             - configMapRef:
-                name: app-config-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-app-config
             {{- end }}
            {{- if .Values.main.secret }}
             - secretRef:
-                name: app-secret-{{ include "n8n.fullname" . }}
+                name: {{ include "n8n.fullname" . }}-app-secret
             {{- end }}
           env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.main.extraEnv }}

--- a/charts/n8n/templates/secret.webhook.yaml
+++ b/charts/n8n/templates/secret.webhook.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: webhook-secret-{{ include "n8n.fullname" . }}
+  name: {{ include "n8n.fullname" . }}-webhook-secret
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/n8n/templates/secret.worker.yaml
+++ b/charts/n8n/templates/secret.worker.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: worker-secret-{{ include "n8n.fullname" . }}
+  name: {{ include "n8n.fullname" . }}-worker-secret
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/n8n/templates/secret.yaml
+++ b/charts/n8n/templates/secret.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: app-secret-{{ include "n8n.fullname" . }}
+  name: {{ include "n8n.fullname" . }}-app-secret
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 type: Opaque


### PR DESCRIPTION
Based on https://helm.sh/docs/chart_template_guide/named_templates/
> One popular naming convention is to prefix each defined template with the name of the chart: {{ define "mychart.labels" }}. By using the specific chart name as a prefix we can avoid any conflicts that may arise due to two different charts that implement templates of the same name.

This PR ensures the fullname is used as prefix instead of suffix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Standardized naming conventions across Kubernetes resources (configuration maps, deployments, and secret references) to enhance clarity and consistency.
	- Updated the Helm chart version from 1.0.3 to 1.0.4.
	- Added an annotation to specify the change in naming convention.
	- No functional changes were introduced; adjustments are solely for improved internal resource identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->