### PR TITLE
Add external runner as sidecar for main

### DIFF
--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -99,6 +99,53 @@ spec:
           {{- if .Values.main.extraVolumeMounts }}
             {{- toYaml .Values.main.extraVolumeMounts | nindent 12 }}
           {{- end }}
+        {{- if .Values.main.sidecar.runner.enabled }}
+        - name: {{ .Chart.Name }}-runner
+          {{- with .Values.main.sidecar.runner.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.main.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            {{- if .Values.main.config }}
+            - configMapRef:
+                name: {{ include "n8n.fullname" . }}-app-config
+            {{- end }}
+           {{- if .Values.main.secret }}
+            - secretRef:
+                name: {{ include "n8n.fullname" . }}-app-secret
+            {{- end }}
+          env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}
+            {{- range $key, $value := .Values.main.extraEnv }}
+            - name: {{ $key }}
+              {{- toYaml $value | nindent 14 }}
+            {{- end }}
+          lifecycle:
+            {{- toYaml .Values.main.sidecar.runner.lifecycle | nindent 12 }}
+{{/*          ports:*/}}
+{{/*            - name: http*/}}
+{{/*              containerPort: {{ get (default (dict) .Values.main.config) "port" | default 5678 }}*/}}
+{{/*              protocol: TCP*/}}
+{{/*          {{- with .Values.main.livenessProbe }}*/}}
+{{/*          livenessProbe:*/}}
+{{/*            {{- toYaml . | nindent 12 }}*/}}
+{{/*          {{- end }}*/}}
+{{/*          {{- with .Values.main.readinessProbe }}*/}}
+{{/*          readinessProbe:*/}}
+{{/*            {{- toYaml . | nindent 12 }}*/}}
+{{/*          {{- end }}*/}}
+          resources:
+            {{- toYaml .Values.main.sidecar.runner.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /home/node/.n8n
+          {{- if .Values.main.extraVolumeMounts }}
+            {{- toYaml .Values.main.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+        {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -125,18 +125,18 @@ spec:
             {{- end }}
           lifecycle:
             {{- toYaml .Values.main.sidecar.runner.lifecycle | nindent 12 }}
-{{/*          ports:*/}}
-{{/*            - name: http*/}}
-{{/*              containerPort: {{ get (default (dict) .Values.main.config) "port" | default 5678 }}*/}}
-{{/*              protocol: TCP*/}}
-{{/*          {{- with .Values.main.livenessProbe }}*/}}
-{{/*          livenessProbe:*/}}
-{{/*            {{- toYaml . | nindent 12 }}*/}}
-{{/*          {{- end }}*/}}
-{{/*          {{- with .Values.main.readinessProbe }}*/}}
-{{/*          readinessProbe:*/}}
-{{/*            {{- toYaml . | nindent 12 }}*/}}
-{{/*          {{- end }}*/}}
+          ports:
+            - name: healthcheck
+              containerPort: {{ get (default (dict) .Values.main.config) "n8n.runners.launcher.health.check.port" | default 5680 }}
+              protocol: TCP
+          {{- with .Values.main.sidecar.runner.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.main.sidecar.runner.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.main.sidecar.runner.resources | nindent 12 }}
           volumeMounts:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -260,6 +260,38 @@ main:
   tolerations: []
   affinity: {}
 
+  # Experimental sidecar settings, use it with caution.
+  sidecar:
+    runner:
+      # Enable the task runner sidecar,
+      # But the following settings are required in the config map for the runner to work:
+      # - n8n.runners.enabled: true
+      # - n8n.runners.mode: external
+      # - n8n.runners.auth.token: <your auth token>
+      enabled: false
+
+      # dedicated runner launcher command
+      # https://docs.n8n.io/hosting/configuration/task-runners/#configuring-task-runners-in-external-mode
+      command: ["/usr/local/bin/task-runner-launcher", "javascript"]
+
+      # here you can specify lifecycle hooks - it can be used e.g., to easily add packages to the container without building
+      # your own docker image
+      # see https://github.com/8gears/n8n-helm-chart/pull/30
+      lifecycle: {}
+
+      resources: {}
+      # We usually recommend not specifying default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      # limits:
+      #   cpu: 100m
+      #   memory: 128Mi
+      # requests:
+      #   cpu: 100m
+      #   memory: 128Mi
+
+
 # # # # # # # # # # # # # # # #
 #
 # Worker related settings

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -279,6 +279,32 @@ main:
       # see https://github.com/8gears/n8n-helm-chart/pull/30
       lifecycle: {}
 
+      # here you can override the livenessProbe for the runner container
+      # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: healthcheck
+        # initialDelaySeconds: 30
+        # periodSeconds: 10
+        # timeoutSeconds: 5
+        # failureThreshold: 6
+        # successThreshold: 1
+
+      # here you can override the readinessProbe for the runner container
+      # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
+
+      readinessProbe:
+        httpGet:
+          path: /healthz
+          port: healthcheck
+        # initialDelaySeconds: 30
+        # periodSeconds: 10
+        # timeoutSeconds: 5
+        # failureThreshold: 6
+        # successThreshold: 1
+
       resources: {}
       # We usually recommend not specifying default resources and to leave this as a conscious
       # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
*This is an experimental attempt to use an external runner as a sidecar for the main container*

Based on:
https://docs.n8n.io/hosting/configuration/task-runners/#configuring-n8n-instance-in-external-mode
https://github.com/n8n-io/task-runner-launcher/blob/main/docs/development.md

Maybe unrelated but something I noticed when using external runner: https://github.com/n8n-io/n8n/issues/13740

@Vad1mo even when still WIP, I would appreciate your feedback on this approach.
Also on the naming and how to use it, I think this would be a great opportunity.

**This runner is only for test execution on the main instance, it is not intended to use as a real runner at this time**
The intension is to keep the main container stable, while the runner can run in out of memory without crashing the main container too.

<img width="985" alt="image" src="https://github.com/user-attachments/assets/31fb150a-40d8-43a6-b56a-23a91408d603" />
<img width="498" alt="image" src="https://github.com/user-attachments/assets/be83e058-408d-4c29-b4bc-6914cc476a8e" />


*Would be nice to have push rights to this repo, i am not a fan of keeping a fork up2date*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional task-runner sidecar container to expand deployment capabilities.
	- Added customizable settings for command execution, security parameters, environment variables, lifecycle hooks, resource management, and volume mounting.
	- Provided an experimental configuration section for the sidecar runner, disabled by default, along with guidance for advanced configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->