### PR TITLE
fix: allow external valkey instance for webhooks

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.81.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "use fullname as prefix instead of suffix"
+      description: "check if redis hostname is set in webhook valkey check instead of .Values.valkey.enabled"

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -96,8 +96,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Validate Valkey/Redis configuration when webhooks are enabled*/}}
 {{- define "n8n.validateValkey" -}}
-{{- if and .Values.webhook.enabled (not .Values.valkey.enabled) -}}
-{{- fail "Webhook processes rely on Valkey. Please set valkey.enabled=true when webhook.enabled=true" -}}
+{{- $envVars := fromYaml (include "toEnvVars" (dict "values" .Values.main.config "prefix" "")) -}}
+{{- if and .Values.webhook.enabled (not $envVars.QUEUE_BULL_REDIS_HOST) -}}
+{{- fail "Webhook processes rely on Valkey. Please set a Redis/Valkey host when webhook.enabled=true" -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
In our configuration, we use an external, Cloud-provider managed Redis instance. However, in the current configuration, we aren't able to enable webhooks, because the chart expects the integrated Valkey instance to be enabled, which we don't want.

This PR changes the `n8n.validateValkey` template to fail if a Redis/Valkey host hasn't been set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced configuration validation when webhooks are enabled, ensuring users receive a clearer error message directing them to set the correct Redis/Valkey host configuration.
- **Updates**
	- Updated version number of the n8n Helm chart from 1.0.4 to 1.0.5.
	- Revised annotation description to reflect changes in webhook valkey check functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->