### PR TITLE
fix: Unify workers replica variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 > [!WARNING]
 > Version 1.0.0 of this Chart includes breaking changes and is not backwards compatible with previous versions.
 > Please review the migration guide below before upgrading.
-> 
+>
 
 
 # n8n Helm Chart for Kubernetes
@@ -57,7 +57,7 @@ main:
         encryption_key: "my_secret" # ==> turns into ENV: N8N_ENCRYPTION_KEY=my_secret
       db:
         type: postgresdb # ==> turns into ENV: DB_TYPE=postgresdb
-        postgresdb: 
+        postgresdb:
           host: 192.168.0.52 # ==> turns into ENV: DB_POSTGRESDB_HOST=192.168.0.52
       node:
         function_allow_builtin: "*" # ==> turns into ENV: NODE_FUNCTION_ALLOW_BUILTIN="*"
@@ -375,7 +375,6 @@ worker:
   # Extra environmental variables, so you can reference other configmaps and secrets into n8n as env vars.
   extraEnv: {}
 
-  count: 2
   # Define the number of jobs a worker can run in parallel by using the concurrency flag. Default is 10
   concurrency: 10
 
@@ -410,6 +409,7 @@ worker:
     size: 1Gi
     # Use an existing PVC
     # existingClaim:
+
   # Number of desired pods.
   replicaCount: 1
 
@@ -808,7 +808,7 @@ scaling:
   enabled: true
 ```
 
-You can define to spawn more workers, by set scaling.worker.count to a higher
+You can define to spawn more workers, by set scaling.worker.replicaCount to a higher
 number.
 Also, it is possible to define your own external redis server.
 
@@ -831,5 +831,5 @@ instance is disabled and by default a single webhook instance is started.
 ## Chart Release Workflow
 
 1. Update the `Chart.yaml` with the new version numbers for the chart and/or app.
-2. In `Chart.yaml`update/replace the content of the `artifacthub.io/changes` section. See Artifacthub [annotation referene](https://artifacthub.io/docs/topics/annotations/helm/) 
+2. In `Chart.yaml`update/replace the content of the `artifacthub.io/changes` section. See Artifacthub [annotation referene](https://artifacthub.io/docs/topics/annotations/helm/)
 3. In GitHub create a new release with the the chart version number as the tag and a title.

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.4
+version: 1.0.5
 appVersion: 1.81.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "use fullname as prefix instead of suffix"
+      description: "unify worker replica variable with other deployments"

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -14,7 +14,7 @@ metadata:
   {{- end }}
 spec:
   {{- if not .Values.worker.autoscaling.enabled }}
-  replicas: {{ .Values.worker.count }}
+  replicas: {{ .Values.worker.replicaCount }}
   {{- end }}
   strategy:
     type: {{ .Values.worker.deploymentStrategy.type }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -276,7 +276,6 @@ worker:
   # Extra environmental variables, so you can reference other configmaps and secrets into n8n as env vars.
   extraEnv: {}
 
-  count: 2
   # Define the number of jobs a worker can run in parallel by using the concurrency flag. Default is 10
   concurrency: 10
 
@@ -311,6 +310,7 @@ worker:
     size: 1Gi
     # Use an existing PVC
     # existingClaim:
+
   # Number of desired pods.
   replicaCount: 1
 


### PR DESCRIPTION
Currently all templates use replicaCount while worker template still uses "count", which brings unnecessary confusion when working with count of replicas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced guidance with improved formatting and clarity, now detailing a more descriptive parameter for configuring worker instances.
  
- **Chore**
	- Updated the deployment version.
	- Unified the worker instance configuration by replacing the previous parameter with a more consistent, clearly named alternative.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->