### PR TITLE
Fix key 'database' to 'db' in secret section of values.yaml

### DIFF
--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -64,7 +64,7 @@ main:
   #     if you run n8n stateless, you should provide an encryption key here.
   #      encryption_key:
   #
-  #    database:
+  #    db:
   #      postgresdb:
   #        password: 'big secret'
 


### PR DESCRIPTION
This hit me when I migrated my values from old values.yaml to the new one :-)
Since there is no obvious direct error messages, it could take a while to figure it out...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined commented configuration labels for consistency. This update is purely cosmetic and does not affect active functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->