### PR TITLE
feat(helm): Support `dnsconfig` in deployments

### DIFF
--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -140,4 +140,8 @@ spec:
         {{- if .Values.webhook.extraVolumes }}
           {{- toYaml .Values.webhook.extraVolumes | nindent 8 }}
         {{- end }}
+      {{- if .Values.webhook.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.webhook.dnsConfig | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -136,4 +136,8 @@ spec:
         {{- if .Values.worker.extraVolumes }}
           {{- toYaml .Values.worker.extraVolumes | nindent 8 }}
         {{- end }}
+      {{- if .Values.worker.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.worker.dnsConfig | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -121,3 +121,7 @@ spec:
         {{- if .Values.main.extraVolumes }}
           {{- toYaml .Values.main.extraVolumes | nindent 8 }}
         {{- end }}
+      {{- if .Values.main.dnsConfig }}
+      dnsConfig:
+        {{- toYaml .Values.main.dnsConfig | nindent 8 }}
+      {{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -260,6 +260,13 @@ main:
   tolerations: []
   affinity: {}
 
+  # dnsConfig allows to specify DNS configuration for the pod.
+  # See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
+    # options:
+    #   - name: ndots
+    #     value: "2"
+
 # # # # # # # # # # # # # # # #
 #
 # Worker related settings
@@ -445,6 +452,13 @@ worker:
   tolerations: []
   affinity: {}
 
+  # dnsConfig allows to specify DNS configuration for the pod.
+  # See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
+    # options:
+    #   - name: ndots
+    #     value: "2"
+
 # Webhook related settings
 # With .Values.scaling.webhook.enabled=true you disable Webhooks from the main process, but you enable the processing on a different Webhook instance.
 # See https://github.com/8gears/n8n-helm-chart/issues/39#issuecomment-1579991754 for the full explanation.
@@ -629,6 +643,13 @@ webhook:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+  # dnsConfig allows to specify DNS configuration for the pod.
+  # See https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config
+  dnsConfig: {}
+    # options:
+    #   - name: ndots
+    #     value: "2"
 
 #
 # User defined supplementary K8s manifests


### PR DESCRIPTION
## Background

By supporting the customization of `dnsConfig`, cluster administrators can adjust settings to fit their cluster DNS environment, allowing them to handle network issues like CoreDNS CPU overload caused by Kyverno more flexibly.

## Changes

- Support setting the [dnsConfig](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-dns-config) value in the deployment templates for the n8n webhook, worker, and main pods.