### PR TITLE
add extraContainers support

### DIFF
--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -119,6 +119,9 @@ spec:
           {{- if .Values.webhook.extraVolumeMounts }}
             {{- toYaml .Values.webhook.extraVolumeMounts | nindent 12 }}
           {{- end }}
+        {{- if .Values.webhook.extraContainers }}
+          {{ tpl (toYaml .Values.webhook.extraContainers) . | nindent 8}}
+        {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -115,6 +115,9 @@ spec:
           {{- if .Values.worker.extraVolumeMounts }}
             {{- toYaml .Values.worker.extraVolumeMounts | nindent 12 }}
           {{- end }}
+        {{- if .Values.worker.extraContainers }}
+          {{ tpl (toYaml .Values.worker.extraContainers) . | nindent 8}}
+        {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -100,6 +100,9 @@ spec:
           {{- if .Values.main.extraVolumeMounts }}
             {{- toYaml .Values.main.extraVolumeMounts | nindent 12 }}
           {{- end }}
+        {{- if .Values.main.extraContainers }}
+          {{ tpl (toYaml .Values.main.extraContainers) . | nindent 8}}
+        {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -271,6 +271,13 @@ main:
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
 
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: null
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
+
 # # # # # # # # # # # # # # # #
 #
 # Worker related settings
@@ -459,6 +466,13 @@ worker:
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
 
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: null
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
+
 # Webhook related settings
 # With .Values.scaling.webhook.enabled=true you disable Webhooks from the main process, but you enable the processing on a different Webhook instance.
 # See https://github.com/8gears/n8n-helm-chart/issues/39#issuecomment-1579991754 for the full explanation.
@@ -646,6 +660,13 @@ webhook:
 
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
+
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: null
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
 
 #
 # User defined supplementary K8s manifests


### PR DESCRIPTION
basic support for extraContainers support.

Totally inspired by the Vault chart:
https://artifacthub.io/packages/helm/hashicorp/vault

Have a good day :) 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Support for adding extra (sidecar) containers to main, worker, and webhook deployments via Helm values.
  - Allows injecting custom containers alongside primary containers to extend functionality (e.g., logging, metrics, proxies).

- **Documentation**
  - Helm values updated to document new extraContainers fields and include example sidecar entries for each deployment type.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->