### PR TITLE
feat: add the ability to toggle service creation

### DIFF
--- a/charts/n8n/templates/service.yaml
+++ b/charts/n8n/templates/service.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.service.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,3 +19,4 @@ spec:
   selector:
     {{- include "n8n.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/type: master
+{{ end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -230,6 +230,7 @@ main:
 
 
   service:
+    enabled: true
     annotations: {}
     # -- Service types allow you to specify what kind of Service you want.
     # E.g., ClusterIP, NodePort, LoadBalancer, ExternalName


### PR DESCRIPTION
## What

- Makes the Kubernetes Service resource optional by wiring the template to `values.yaml` → `service.enabled` (defaults to `true` to keep current behaviour).

## Why

- Our platform team stamps out Services & NLBs with a dedicated component that adds mandatory AWS annotations, tagging, and TLS bits. Letting Helm create a second Service just collides with names and spawns an unwanted NLB
- Many shops run ingress, mesh, or LB controllers that own Service objects. Being forced to accept the chart’s Service ties their hands