### PR TITLE
Fix typo in README's configuration example 'database' -> 'db'

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ main:
   #     if you run n8n stateless, you should provide an encryption key here.
   #      encryption_key:
   #
-  #    database:
+  #    db:
   #      postgresdb:
   #        password: 'big secret'
 


### PR DESCRIPTION
When using the provided example as a basis for a new configuration file, there was a configuration error, as `main.config.secret.db` was written as `main.config.secret.database`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the example configuration in the README to use the correct key name for database settings, ensuring consistency with other documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->