### PR TITLE
fix: allow empty tls configuration for ingress

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.10
+version: 1.0.11
 appVersion: 1.99.1
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "rollback of a fix that actually broke things: https://github.com/8gears/n8n-helm-chart/issues/200"
+      description: "allows empty tls for ingres: fixes https://github.com/8gears/n8n-helm-chart/issues/167"

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -40,10 +40,10 @@ ingress:
   hosts:
     - host: workflow.example.com
       paths: []
-  tls:
-    - hosts:
-        - workflow.example.com
-      secretName: host-domain-cert
+  tls: []
+    #- hosts:
+    #    - workflow.example.com
+    #  secretName: host-domain-cert
 
 # the main (n8n) application related configuration + Kubernetes specific settings
 # The config: {} dictionary is converted to environmental variables in the ConfigMap.

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -41,7 +41,7 @@ ingress:
     - host: workflow.example.com
       paths: []
   tls: []
-    #- hosts:
+    # - hosts:
     #    - workflow.example.com
     #  secretName: host-domain-cert
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -15,3 +15,20 @@ for to help you get started with a setup for your particular use case.
 ```shell
 helm template n8n charts/n8n -f examples/values_full.yaml > manifests.yaml
 ```
+
+
+## Test Examples
+
+If you want to text or deploy this examples with postgresdb, we recommend the use
+cloudnative-pg.
+
+The `full` and `small-prod` examples already deploy a database instance.
+
+See [installation guide](https://cloudnative-pg.io/documentation/1.26/installation_upgrade/) for all details.
+
+```shell
+kubectl apply --server-side -f \
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.26/releases/cnpg-1.26.0.yaml
+kubectl rollout status deployment \
+  -n cnpg-system cnpg-controller-manager
+```


### PR DESCRIPTION
fixes https://github.com/8gears/n8n-helm-chart/issues/167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with ingress configuration by allowing empty TLS settings, addressing a previous problem with mandatory TLS values.

- **Documentation**
  - Updated the examples README with instructions for deploying test setups that require a PostgreSQL database, including guidance on installing the cloudnative-pg operator.

- **Chores**
  - Incremented the Helm chart version for n8n to 1.0.11.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->