### PR TITLE
refactor(deployment/values): get container port from the right config

### DIFF
--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
             {{- toYaml .Values.main.lifecycle | nindent 12 }}
           ports:
             - name: http
-              containerPort: {{ get (default (dict) .Values.main.config) "port" | default 5678 }}
+              containerPort: {{ get (default (dict) .Values.main.config.n8n) "port" | default 5678 }}
               protocol: TCP
           {{- with .Values.main.livenessProbe }}
           livenessProbe:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -200,10 +200,10 @@ main:
   # here you can override the livenessProbe for the main container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
 
-  livenessProbe: {}
-    # httpGet:
-    #   path: /healthz
-    #   port: http
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -213,10 +213,10 @@ main:
   # here you can override the readinessProbe for the main container
   # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
 
-  readinessProbe: {}
-    # httpGet:
-    #   path: /healthz
-    #   port: http
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -393,10 +393,10 @@ worker:
 
   # here you can override the livenessProbe for the main container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
-  livenessProbe: {}
-    # httpGet:
-    #   path: /healthz
-    #   port: http
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -406,10 +406,10 @@ worker:
   # here you can override the readinessProbe for the main container
   # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
 
-  readinessProbe: {}
-    # httpGet:
-    #   path: /healthz
-    #   port: http
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -580,10 +580,10 @@ webhook:
   # here you can override the livenessProbe for the main container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
 
-  livenessProbe: {}
-    # httpGet:
-    #   path: /healthz
-    #   port: http
+  livenessProbe:
+    httpGet:
+      path: /healthz
+      port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -593,10 +593,10 @@ webhook:
   # here you can override the readinessProbe for the main container
   # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
 
-  readinessProbe: {}
-    # httpGet:
-    #   path: /healthz
-    #   port: http
+  readinessProbe:
+    httpGet:
+      path: /healthz
+      port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -200,10 +200,10 @@ main:
   # here you can override the livenessProbe for the main container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
 
-  livenessProbe:
-    httpGet:
-      path: /healthz
-      port: http
+  livenessProbe: {}
+    # httpGet:
+    #   path: /healthz
+    #   port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -213,10 +213,10 @@ main:
   # here you can override the readinessProbe for the main container
   # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
 
-  readinessProbe:
-    httpGet:
-      path: /healthz
-      port: http
+  readinessProbe: {}
+    # httpGet:
+    #   path: /healthz
+    #   port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -393,10 +393,10 @@ worker:
 
   # here you can override the livenessProbe for the main container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
-  livenessProbe:
-    httpGet:
-      path: /healthz
-      port: http
+  livenessProbe: {}
+    # httpGet:
+    #   path: /healthz
+    #   port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -406,10 +406,10 @@ worker:
   # here you can override the readinessProbe for the main container
   # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
 
-  readinessProbe:
-    httpGet:
-      path: /healthz
-      port: http
+  readinessProbe: {}
+    # httpGet:
+    #   path: /healthz
+    #   port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -580,10 +580,10 @@ webhook:
   # here you can override the livenessProbe for the main container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
 
-  livenessProbe:
-    httpGet:
-      path: /healthz
-      port: http
+  livenessProbe: {}
+    # httpGet:
+    #   path: /healthz
+    #   port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5
@@ -593,10 +593,10 @@ webhook:
   # here you can override the readinessProbe for the main container
   # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
 
-  readinessProbe:
-    httpGet:
-      path: /healthz
-      port: http
+  readinessProbe: {}
+    # httpGet:
+    #   path: /healthz
+    #   port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
     # timeoutSeconds: 5


### PR DESCRIPTION
Currently values is taking container port and putting it as an environment variable. Yet, n8n is evaluating its environment variable and causing an error as `PORT=1234` is NOT correct env var.

Instead, should be `N8N_PORT=1234` 

Secondly, worker is being restarted ever few seconds due to liveness probe. Logs indicating that the container is ready and working. After few seconds, it signals to shutdown as healthz is not returning 200. Hence, Avoid enabling the Probe by default and allowing user to enable/disable if he wish to

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the configuration path for the HTTP port in the deployment template.
  * Disabled default liveness and readiness probes for containers, while preserving the previous probe configurations as comments for future reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->