### PR TITLE
feat: add GitHub Action to auto-merge Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,61 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    branches: [ main, master ]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      # Wait for lint-test job to pass
+      - name: Wait for lint-test
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'lint-test'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+      
+      # Wait for linter-artifacthub job to pass
+      - name: Wait for linter-artifacthub
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'linter-artifacthub'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+      
+      # Wait for conventional commits check to pass
+      - name: Wait for conventional commits check
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          check-name: 'Conventional Commits'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 20
+      
+      # Approve the PR
+      - name: Approve Pull Request
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      # Enable auto-merge
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a GitHub Action workflow that automatically merges Dependabot pull requests when all tests are passing.

## Features
- Automatically approves and merges Dependabot PRs
- Waits for all required checks to pass before merging:
  - lint-test
  - linter-artifacthub
  - Conventional Commits
- Works on both main and master branches
- Uses GitHub CLI to approve and enable auto-merge

This will reduce maintenance overhead by automatically handling dependency updates that pass all tests.

@Vad1mo can click here to [continue refining the PR](https://app.all-hands.dev/conversations/14006af4723c4f9988357a9c1e919c7c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated workflow to approve and enable auto-merge for Dependabot pull requests after required checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->