### PR TITLE
Change default service name to prevent conflic with N8N_PORT

### DIFF
--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: {{ $fullName }}
+                name: {{ $fullName }}-svc
                 port:
                   number: {{ $.Values.main.service.port | default 80  }}
           {{- if $.Values.webhook.enabled }}

--- a/charts/n8n/templates/service.yaml
+++ b/charts/n8n/templates/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "n8n.fullname" . }}
+  name: {{ include "n8n.fullname" . }}-svc
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
   {{- with .Values.main.service.annotations }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the service naming convention in deployment templates by appending a `-svc` suffix to the service name.
  * Adjusted ingress configuration to reference the updated service name for routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->