### PR TITLE
Fix: prevent workers restart when valkey configuration is updated

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.11
+version: 1.0.12
 appVersion: 1.99.1
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "allows empty tls for ingres: fixes https://github.com/8gears/n8n-helm-chart/issues/167"
+      description: "prevent workers restart when Valkey configuration is updated: fixes https://github.com/8gears/n8n-helm-chart/issues/214"

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ print .Values | sha256sum }}
+        checksum/config: {{ merge .Values.main .Values.worker .Values.webhook | toJson | sha256sum }}
         {{- with .Values.worker.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
A quick fix for #214. The checksum is no longer dependent on Valkey configuration changes, i.e. services are decoupled.