### PR TITLE
fix(helm): adds metadata.namespace field to templated resources

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.11
+version: 1.0.12
 appVersion: 1.99.1
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: fixed
-      description: "allows empty tls for ingres: fixes https://github.com/8gears/n8n-helm-chart/issues/167"
+      description: "Adds namespace to all namespace-scoped templates: fixes https://github.com/8gears/n8n-helm-chart/issues/224"

--- a/charts/n8n/templates/configmap.webhook.yaml
+++ b/charts/n8n/templates/configmap.webhook.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "n8n.fullname" . }}-webhook-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 data:

--- a/charts/n8n/templates/configmap.worker.yaml
+++ b/charts/n8n/templates/configmap.worker.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "n8n.fullname" . }}-worker-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 data:

--- a/charts/n8n/templates/configmap.yaml
+++ b/charts/n8n/templates/configmap.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "n8n.fullname" . }}-app-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 data:

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -5,6 +5,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "n8n.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     {{- if .Values.webhook.deploymentLabels }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "n8n.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     {{- if .Values.worker.deploymentLabels }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "n8n.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
     {{- if .Values.main.deploymentLabels }}

--- a/charts/n8n/templates/hpa.yaml
+++ b/charts/n8n/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "n8n.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 spec:

--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -4,6 +4,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/n8n/templates/pvc.yaml
+++ b/charts/n8n/templates/pvc.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "n8n.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.main.persistence.annotations }}
   annotations:
     {{- range $key, $value := . }}

--- a/charts/n8n/templates/secret.webhook.yaml
+++ b/charts/n8n/templates/secret.webhook.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "n8n.fullname" . }}-webhook-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/n8n/templates/secret.worker.yaml
+++ b/charts/n8n/templates/secret.worker.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "n8n.fullname" . }}-worker-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/n8n/templates/secret.yaml
+++ b/charts/n8n/templates/secret.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "n8n.fullname" . }}-app-secret
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/n8n/templates/service.webhook.yaml
+++ b/charts/n8n/templates/service.webhook.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "n8n.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
   {{- with .Values.webhook.service.annotations }}

--- a/charts/n8n/templates/service.yaml
+++ b/charts/n8n/templates/service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "n8n.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
   {{- with .Values.main.service.annotations }}

--- a/charts/n8n/templates/serviceaccount.yaml
+++ b/charts/n8n/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "n8n.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "n8n.labels" . | nindent 4 }}
   {{- with .Values.main.serviceAccount.annotations }}


### PR DESCRIPTION
Fixes https://github.com/8gears/n8n-helm-chart/issues/224

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensure all namespace-scoped resources explicitly use the release namespace (Deployments, Services, ConfigMaps, Secrets, ServiceAccount, Ingress, HPA, PVC) to improve reliability when installing into non-default namespaces.

- **Chores**
  - Bump Helm chart version to 1.0.13.
  - Update release/change notes annotation to reflect namespace additions across templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->