### PR TITLE
fix: typo in contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -835,7 +835,7 @@ instance is disabled and by default a single webhook instance is started.
 3. In `Chart.yaml`, replace the content of the `artifacthub.io/changes` section. See the ArtifactHub [annotation reference](https://artifacthub.io/docs/topics/annotations/helm/).
 4. Run `ah lint` locally
 5. Run Chart-Testing  `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
-6. Install the charts and examples locall to see if they work
+6. Install the charts and examples locally to see if they work
 7. Submit your PR
 8. The maintainers create a new release in GitHub using the chart version number as the tag and title.
 


### PR DESCRIPTION
Intall -> Install

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed typos in the Contribution Guide (step 6) — "Intall" → "Install" and "locall" → "locally". Updated wording now reads: "6. Install the charts and examples locally to see if they work." Improves clarity for contributors following setup instructions. No functional/runtime changes; estimated review effort: low.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->