### PR TITLE
feat: Support container resize policy for runtime resource updates

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.12
+version: 1.1.0
 appVersion: 1.107.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,7 +34,8 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "allows empty tls for ingres: fixes https://github.com/8gears/n8n-helm-chart/issues/167"
-    - kind: changed
-      description: "Bump appVersion to n8n 1.107.4."
+    - kind: added
+      description: Add support spec.containers.resizePolicy for all containers. This allows to control the behavior when a container is resized.
+      links:
+        - name: GitHub PR
+          url: https://github.com/8gears/n8n-helm-chart/pull/232 

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -112,6 +112,10 @@ spec:
             {{- toYaml .Values.webhook.securityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.webhook.resources | nindent 12 }}
+          {{- with .Values.webhook.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -108,6 +108,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.worker.resources | nindent 12 }}
+          {{- with .Values.worker.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.main.resources | nindent 12 }}
+          {{- with .Values.main.resizePolicy }}
+          resizePolicy:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /home/node/.n8n

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -255,6 +255,13 @@ main:
   #   cpu: 100m
   #   memory: 128Mi
 
+  # Container resize policy allows runtime resource updates without pod restart
+  resizePolicy: []
+    # - resourceName: cpu
+    #   restartPolicy: NotRequired
+    # - resourceName: memory
+    #   restartPolicy: RestartContainer
+
   autoscaling:
     enabled: false
     minReplicas: 1
@@ -439,6 +446,13 @@ worker:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+  # Container resize policy allows runtime resource updates without pod restart
+  resizePolicy: []
+    # - resourceName: cpu
+    #   restartPolicy: NotRequired
+    # - resourceName: memory
+    #   restartPolicy: RestartContainer
 
   autoscaling:
     enabled: false
@@ -626,6 +640,14 @@ webhook:
   # requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+  # Container resize policy allows runtime resource updates without pod restart
+  resizePolicy: []
+    # - resourceName: cpu
+    #   restartPolicy: NotRequired
+    # - resourceName: memory
+    #   restartPolicy: RestartContainer
+
   autoscaling:
     enabled: false
     minReplicas: 1


### PR DESCRIPTION
## Changes

- Add support spec.containers.resizePolicy field in deployment. This feature allows CPU and memory resources to be modified without pod restart or replacement.
- Bump minor chart version

## Reference

- [Resize CPU and Memory Resources assigned to Containers](https://kubernetes.io/docs/tasks/configure-pod-container/resize-container-resources/)