### PR TITLE
fixed helm schema argument, added missing dash

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Push charts to 8gears.container-registry.com
         run: |
           helm plugin install https://github.com/losisin/helm-values-schema-json.git
-          helm schema -input charts/n8n/values.yaml
+          helm schema --input charts/n8n/values.yaml
           echo "Skip copying the schema values file for now, as it needs more testing."
           cp -a README.md LICENSE charts/n8n/
           package_path=$(helm package charts/n8n --dependency-update | grep -o '/.*\.tgz')


### PR DESCRIPTION
I saw the build failing on the following error:
```
Installed plugin: schema
Error: unknown shorthand flag: 'i' in -input
Error: plugin "schema" exited with error
Error: Process completed with exit code 1.
```

I guess this should fix it.