### PR TITLE
feat: add support for extraEnvFrom to main, worker and webhook

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.14
+version: 1.0.15
 appVersion: 1.109.1
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update n8n app version to 1.109.1"
+      description: "Added support for extraEnvFrom to main, worker and webhook"

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -101,6 +101,9 @@ spec:
             - secretRef:
                 name: {{ include "n8n.fullname" . }}-webhook-secret
             {{- end }}
+            {{- if .Values.webhook.extraEnvFrom }}
+            {{- toYaml .Values.webhook.extraEnvFrom | nindent 12 }}
+            {{- end }}
 
           env: {{ not (empty .Values.webhook.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.webhook.extraEnv }}

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -104,7 +104,6 @@ spec:
             {{- if .Values.webhook.extraEnvFrom }}
             {{- toYaml .Values.webhook.extraEnvFrom | nindent 12 }}
             {{- end }}
-
           env: {{ not (empty .Values.webhook.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.webhook.extraEnv }}
             - name: {{ $key }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -76,6 +76,10 @@ spec:
             - secretRef:
                 name: {{ include "n8n.fullname" . }}-worker-secret
             {{- end }}
+            {{- if .Values.worker.extraEnvFrom }}
+            {{- toYaml .Values.worker.extraEnvFrom | nindent 12 }}
+            {{- end }}
+
           env: {{ not (empty .Values.worker.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.worker.extraEnv }}
             - name: {{ $key }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -79,7 +79,6 @@ spec:
             {{- if .Values.worker.extraEnvFrom }}
             {{- toYaml .Values.worker.extraEnvFrom | nindent 12 }}
             {{- end }}
-
           env: {{ not (empty .Values.worker.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.worker.extraEnv }}
             - name: {{ $key }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -73,6 +73,10 @@ spec:
             - secretRef:
                 name: {{ include "n8n.fullname" . }}-app-secret
             {{- end }}
+            {{- if .Values.main.extraEnvFrom }}
+            {{- toYaml .Values.main.extraEnvFrom | nindent 12 }}
+            {{- end }}
+
           env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.main.extraEnv }}
             - name: {{ $key }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -76,7 +76,6 @@ spec:
             {{- if .Values.main.extraEnvFrom }}
             {{- toYaml .Values.main.extraEnvFrom | nindent 12 }}
             {{- end }}
-
           env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.main.extraEnv }}
             - name: {{ $key }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -83,6 +83,11 @@ main:
   #
   # N8n Kubernetes specific settings
   #
+  extraEnvFrom: []
+  #    - configMapRef:
+  #        name: my-config
+  #    - secretRef:
+  #        name: my-secret
   persistence:
     # If true, use a Persistent Volume Claim, If false, use emptyDir
     enabled: false
@@ -288,6 +293,11 @@ worker:
   #
   # Worker Kubernetes specific settings
   #
+  extraEnvFrom: []
+  #    - configMapRef:
+  #        name: my-config
+  #    - secretRef:
+  #        name: my-secret
   persistence:
     # If true, use a Persistent Volume Claim, If false, use emptyDir
     enabled: false
@@ -467,8 +477,12 @@ webhook:
   #   WEBHOOK_URL:
   #   value: "http://webhook.domain.tld"
 
+  extraEnvFrom: []
+  #    - configMapRef:
+  #        name: my-config
+  #    - secretRef:
+  #        name: my-secret
 
-  #
   # Webhook Kubernetes specific settings
   #
   persistence:


### PR DESCRIPTION
### Description

This pull request introduces support for `extraEnvFrom` to the `main`, `worker`, and `webhook` deployments, as requested in issue [#139](https://github.com/8gears/n8n-helm-chart/issues/139).

This feature allows for more flexible and secure configuration by enabling the injection of environment variables from external `ConfigMaps` and `Secrets` directly into the pods. This is particularly useful for managing sensitive information like credentials or API keys without hardcoding them into the `values.yaml` file.

The implementation is consistent with existing patterns in the chart and adds the `extraEnvFrom` parameter under the `main`, `worker`, and `webhook` sections in `values.yaml`.

### How to Use

To use this feature, you can now specify `ConfigMap` or `Secret` references in your `values.yaml` file as follows:

```yaml
main:
  extraEnvFrom:
    - secretRef:
        name: my-n8n-secrets
    - configMapRef:
        name: my-n8n-config

worker:
  extraEnvFrom:
    - secretRef:
        name: my-worker-secrets
    - configMapRef:
        name: my-worker-config

webhook:
  extraEnvFrom:
    - secretRef:
        name: my-webhook-secrets
    - configMapRef:
        name: my-webhook-config
```

### Changes Included

-   **`values.yaml`**: Added a new `extraEnvFrom: []` field to the `main`, `worker`, and `webhook` sections.
-   **`templates/deployment.yaml`**: Updated the main deployment to include the `envFrom` block if `.Values.main.extraEnvFrom` is set.
-   **`templates/deployment.worker.yaml`**: Updated the worker deployment to include the `envFrom` block.
-   **`templates/deployment.webhook.yaml`**: Updated the webhook deployment to include the `envFrom` block.
-   **`Chart.yaml`**: Bumped the chart version to `1.0.15` to reflect the new feature.

### Testing

I have tested this feature locally with two scenarios to ensure correctness and robustness.

1.  **Failure Case (Invalid Configuration):** I first ran a deployment with an incorrect field inside `extraEnvFrom` (e.g., `error:` instead of `secretRef:`). The deployment correctly failed with a validation error, confirming that Kubernetes' native validation is enforced through the chart.

![n8n_error_test](https://github.com/user-attachments/assets/6dcac81c-8e9b-458f-8166-ade88b5b0f23)

2.  **Success Case (Valid Configuration):** I then ran `helm install` using a `test-values.yaml` file that configured both a `ConfigMap` and a `Secret` for `extraEnvFrom`. The installation was successful, and I verified with `kubectl get pod -o yaml` that the `envFrom` sections were correctly added to the running `n8n` and `n8n-worker` pods.

![n8n_success_test](https://github.com/user-attachments/assets/4fbd275d-931f-482e-9352-5e0e83d0f47f)

This PR resolves #139.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for extraEnvFrom on main, worker, and webhook to include additional environment sources (e.g., ConfigMaps/Secrets) without affecting existing entries.
* **Documentation**
  * Provided commented examples in values configuration for using configMapRef and secretRef; minor comment cleanup.
* **Chores**
  * Bumped chart version to 1.0.15 and updated release annotations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->