### PR TITLE
feat: add the possibility to set additionalLabels on all the resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,12 @@ nameOverride:
 # Override the full name of the deployment. When empty, the name will be "{release-name}-{chart-name}" or the value of nameOverride if specified
 fullnameOverride:
 
+# Additional labels to be added to all deployed resources by the chart
+additionalLabels: {}
+  # tags.datadoghq.com/env: "<ENV>"
+  # tags.datadoghq.com/service: "<SERVICE>"
+  # tags.datadoghq.com/version: "<VERSION>"
+  
 # Add entries to a pod's /etc/hosts file, mapping custom IP addresses to hostnames.
 hostAliases: []
   #- ip: 8.8.8.8

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.14
+version: 1.1.0
 appVersion: 1.109.1
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update n8n app version to 1.109.1"
+      description: "add the possibility to set additionalLabels on all the resources"

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -40,6 +40,9 @@ helm.sh/chart: {{ include "n8n.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -40,6 +40,9 @@ spec:
       labels:
         {{- include "n8n.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/type: webhook
+        {{- if .Values.additionalLabels }}
+          {{ toYaml .Values.additionalLabels | nindent 8 }}
+        {{- end }}
         {{- if .Values.webhook.podLabels }}
           {{ toYaml .Values.webhook.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -38,6 +38,9 @@ spec:
       labels:
         {{- include "n8n.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/type: worker
+        {{- if .Values.additionalLabels }}
+          {{ toYaml .Values.additionalLabels | nindent 8 }}
+        {{- end }}
         {{- if .Values.worker.podLabels }}
           {{ toYaml .Values.worker.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
       labels:
         {{- include "n8n.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/type: master
+        {{- if .Values.additionalLabels }}
+          {{ toYaml .Values.additionalLabels | nindent 8 }}
+        {{- end }}
         {{- if .Values.main.podLabels }}
           {{ toYaml .Values.main.podLabels | nindent 8 }}
         {{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -24,6 +24,12 @@ nameOverride:
 # Override the full name of the deployment. When empty, the name will be "{release-name}-{chart-name}" or the value of nameOverride if specified
 fullnameOverride:
 
+# Additional labels to be added to all deployed resources by the chart
+additionalLabels: {}
+  # tags.datadoghq.com/env: "<ENV>"
+  # tags.datadoghq.com/service: "<SERVICE>"
+  # tags.datadoghq.com/version: "<VERSION>"
+
 # Add entries to a pod's /etc/hosts file, mapping custom IP addresses to hostnames.
 hostAliases: []
   # - ip: 8.8.8.8


### PR DESCRIPTION
We deploy n8n with this chart in a company.
Because of internal policy, we need to add some labels on all the resources. It's only possible on pod & deployment by default.

This PR add the possibility to set custom labels globally.