### PR TITLE
Update n8n app version to 1.110.1

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
-version: 1.0.14
-appVersion: 1.109.1
+version: 1.0.15
+appVersion: 1.110.1
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
 home: https://github.com/8gears/n8n-helm-chart

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update n8n app version to 1.109.1"
+      description: "Update n8n app version to 1.110.1"


### PR DESCRIPTION
Another PR that updates to the latest n8n app version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Helm chart to version 1.0.15 and aligned app version to 1.110.1.
  * Updated release metadata to reflect the new app version.

Impact:
- Deploying or upgrading with this chart now installs n8n 1.110.1.
- No changes to chart configuration or behavior; upgrade is version-alignment only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->