### PR TITLE
chore: bump n8n chart and app versions to 1.0.15 and 1.112.0

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
-version: 1.0.14
-appVersion: 1.109.1
+version: 1.0.15
+appVersion: 1.112.0
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
 home: https://github.com/8gears/n8n-helm-chart
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update n8n app version to 1.109.1"
+      description: "Update n8n app version to 1.112.0"


### PR DESCRIPTION
This pull request updates the n8n Helm chart to use the latest application version. The most important change is a version bump to ensure users deploy the most recent release of n8n.

Version updates:

* Updated the `version` field in `Chart.yaml` from `1.0.14` to `1.0.15` and the `appVersion` field from `1.109.1` to `1.112.0` to reflect the new release.
* Updated the change annotation to indicate the new n8n app version (`1.112.0`).