### PR TITLE
Change valkey chart

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -26,8 +26,8 @@ maintainers:
 
 dependencies:
   - name: valkey
-    version: 2.4.7
-    repository: oci://registry-1.docker.io/bitnamicharts
+    version: 0.3.2
+    repository: oci://registry-1.docker.io/cloudpirates
     condition: valkey.enabled
 
 annotations:

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.0.15
+version: 1.0.16
 appVersion: 1.113.3
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update n8n app version to 1.112.0"
+      description: "Update n8n app version to 1.113.3 and switch valkey chart from bitnami to cloudpirates"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
 version: 1.0.15
-appVersion: 1.112.0
+appVersion: 1.113.3
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
 home: https://github.com/8gears/n8n-helm-chart


### PR DESCRIPTION
## What this PR does / why we need it

This PR replaces the bitnami valkey chart with the one maintained by cloudpirates. This is required because bitnami stopped support for their free public charts. Also, as I was on it already, I updated n8n app version to the latest available.

## Which issue this PR fixes

none

## Special notes for your reviewer

We already deployed n8n with he new valkey chart and it worked. You may want to test as well.

## Checklist



### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [x] App version updated in `Chart.yaml` if applicable
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))

### Testing and Validation
- [x] Tested chart installation locally


