### PR TITLE
add extraContainers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,13 @@ main:
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
 
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: []
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
+
 # # # # # # # # # # # # # # # #
 #
 # Worker related settings
@@ -546,6 +553,13 @@ worker:
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
 
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: []
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
+
 # Webhook related settings
 # With .Values.scaling.webhook.enabled=true you disable Webhooks from the main process, but you enable the processing on a different Webhook instance.
 # See https://github.com/8gears/n8n-helm-chart/issues/39#issuecomment-1579991754 for the full explanation.
@@ -733,6 +747,13 @@ webhook:
 
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
+
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: []
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
 
 #
 # User defined supplementary K8s manifests

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.1.0
+version: 1.2.0
 appVersion: 1.116.2
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: added
-      description: "Add terminationGracePeriodSeconds configuration for main, worker, and webhook pods"
+      description: "Add extraContainers support for main, workers, and webhooks"

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -119,6 +119,9 @@ spec:
           {{- if .Values.webhook.extraVolumeMounts }}
             {{- toYaml .Values.webhook.extraVolumeMounts | nindent 12 }}
           {{- end }}
+      {{- if .Values.webhook.extraContainers }}
+        {{ tpl (toYaml .Values.webhook.extraContainers) . | nindent 8 }}
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -115,6 +115,9 @@ spec:
           {{- if .Values.worker.extraVolumeMounts }}
             {{- toYaml .Values.worker.extraVolumeMounts | nindent 12 }}
           {{- end }}
+      {{- if .Values.worker.extraContainers }}
+        {{ tpl (toYaml .Values.worker.extraContainers) . | nindent 8 }}
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -100,6 +100,9 @@ spec:
           {{- if .Values.main.extraVolumeMounts }}
             {{- toYaml .Values.main.extraVolumeMounts | nindent 12 }}
           {{- end }}
+      {{- if .Values.main.extraContainers }}
+        {{ tpl (toYaml .Values.main.extraContainers) . | nindent 8 }}
+      {{- end }}
       {{- with .Values.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -126,7 +126,6 @@ main:
   #      mountPath: /etc/ssl/certs/postgresql
   #      readOnly: true
 
-
   # Number of desired pods. More than one pod is supported in n8n enterprise.
   replicaCount: 1
 
@@ -233,7 +232,6 @@ main:
   #        - name: data
   #          mountPath: /home/node/.n8n
 
-
   service:
     enabled: true
     annotations: {}
@@ -268,6 +266,13 @@ main:
 
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
+
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: []
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
 
 # # # # # # # # # # # # # # # #
 #
@@ -457,6 +462,13 @@ worker:
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
 
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: []
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
+
 # Webhook related settings
 # With .Values.scaling.webhook.enabled=true you disable Webhooks from the main process, but you enable the processing on a different Webhook instance.
 # See https://github.com/8gears/n8n-helm-chart/issues/39#issuecomment-1579991754 for the full explanation.
@@ -472,7 +484,6 @@ webhook:
   extraEnv: {}
   #   WEBHOOK_URL:
   #     value: "http://webhook.domain.tld"
-
 
   #
   # Webhook Kubernetes specific settings
@@ -644,6 +655,13 @@ webhook:
 
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
+
+  # extraContainers is a list of sidecar containers. Specified as a YAML list.
+  extraContainers: []
+  # extraContainers:
+  #   - name: my-sidecar
+  #     image: busybox:latest
+  #     command: ["sh", "-c", "while true; do echo hello && sleep 60; done"]
 
 #
 # User defined supplementary K8s manifests


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds basic support for specifying `extraContainers` (sidecar) which can be used in main, worker, and webhook deployments. 

I want this feature added so I can add external n8n runner sidecar with the workers but it is generic enough to allow users to setup any sidecar they need. I tested this locally using:

```yaml
worker:
  extraContainers:
    - name: n8n-runners
      image: "n8nio/runners:1.114.3"
      env:
        - name: N8N_RUNNERS_AUTH_TOKEN
          valueFrom:
            secretKeyRef:
              name: n8n-app-secret
              key: N8N_RUNNERS_AUTH_TOKEN
        - name: N8N_RUNNERS_TASK_BROKER_URI
          value: "http://127.0.0.1:5679"
      ports:
        - name: runner-health
          containerPort: 5680
      livenessProbe:
        httpGet:
          path: /healthz
          port: runner-health
        initialDelaySeconds: 5
        periodSeconds: 10
```

## Special notes for your reviewer

This PR was originally submitted by [ArnaudTA](https://github.com/ArnaudTA) in [PR #180](https://github.com/8gears/n8n-helm-chart/pull/180) but it has sat a month without addressing reviewer concerns. 

## Checklist

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [x] App version updated in `Chart.yaml` if applicable
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [x] Variables are documented in the `README.md`
### Testing and Validation
- [ ] Ran `ah lint` locally without errors
- [ ] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [x] Tested with example configurations in `/examples` directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Add support for configuring extra sidecar containers via extraContainers for main, worker, and webhook deployments (no effect unless configured).

- **Documentation**
  - Values and README updated with commented examples showing how to define extraContainers.

- **Chores**
  - Chart version bumped to 1.2.0 and changelog updated to note extraContainers support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->