### PR TITLE
chore: bump n8n chart and app versions to 1.0.16 and 1.115.2

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
-version: 1.0.15
-appVersion: 1.112.0
+version: 1.0.16
+appVersion: 1.115.2
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
 home: https://github.com/8gears/n8n-helm-chart
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update n8n app version to 1.112.0"
+      description: "Update n8n app version to 1.115.2"


### PR DESCRIPTION
## What this PR does / why we need it
Updates the n8n Helm chart to use the latest application version.

Version updates:
- Updated the version field in Chart.yaml from 1.0.14 to 1.0.15 
- Updated the appVersion field from 1.112.0 to 1.115.2

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [x] App version updated in `Chart.yaml` if applicable

### Testing and Validation
- [x] Ran `ah lint` locally without errors
- [x] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [x] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Helm chart version to 1.0.16.
  * Updated bundled application version to 1.115.2 for the latest improvements and fixes.

* **Documentation**
  * Refreshed changelog metadata to reflect the new application version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->