### PR TITLE
chore: bump n8n chart and app versions to 1.0.16 and 1.116.2

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.7.0
+        with:
+          yamale_version: "6.0.0"
 
       - name: Add Helm Repositories
         run: |

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
-version: 1.0.15
-appVersion: 1.112.0
+version: 1.0.16
+appVersion: 1.115.3
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
 home: https://github.com/8gears/n8n-helm-chart
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update n8n app version to 1.112.0"
+      description: "Update n8n app version to 1.115.3"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
 version: 1.0.16
-appVersion: 1.115.3
+appVersion: 1.116.2
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
 home: https://github.com/8gears/n8n-helm-chart
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update n8n app version to 1.115.3"
+      description: "Update n8n app version to 1.116.2"


### PR DESCRIPTION
## What this PR does / why we need it

This PR updates the n8n Helm chart and application versions to 1.0.16 and 1.116.2 respectively.

## Which issue this PR fixes

<!-- Optional: Link related issues using the format below. Issues will be automatically closed when PR is merged -->
<!-- fixes #123, fixes #456 -->

## Special notes for your reviewer

<!-- Any additional context, special considerations, or things reviewers should pay attention to -->

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [ ] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [ ] App version updated in `Chart.yaml` if applicable
- [ ] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [ ] Variables are documented in the `README.md`
### Testing and Validation
- [ ] Ran `ah lint` locally without errors
- [ ] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [ ] Tested chart installation locally
- [ ] Tested with example configurations in `/examples` directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated application version to 1.116.2, delivering the latest upstream fixes, improvements, and metadata updates.
  * Adjusted CI/lint workflow configuration to use a specific schema validation tool version to stabilize chart validation steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->