### PR TITLE
feat: add startupProbes

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ worker:
   # command args
   commandArgs: []
 
-  # here you can override the startupProbe for the main container
+  # here you can override the startupProbe for the worker container
   # it may be used to increase the timeout for the startupProbe
   startupProbe:
     httpGet:
@@ -505,7 +505,7 @@ worker:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the livenessProbe for the main container
+  # here you can override the livenessProbe for the worker container
   # it may be used to increase the timeout for the livenessProbe
   livenessProbe:
     httpGet:
@@ -517,7 +517,7 @@ worker:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
+  # here you can override the readinessProbe for the worker container
   # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:
@@ -694,7 +694,7 @@ webhook:
   # Command Arguments
   commandArgs: []
 
-  # here you can override the startupProbe for the main container
+  # here you can override the startupProbe for the webhook container
   # it may be used to increase the timeout for the startupProbe
 
   startupProbe:
@@ -707,7 +707,7 @@ webhook:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the livenessProbe for the main container
+  # here you can override the livenessProbe for the webhook container
   # it may be used to increase the timeout for the livenessProbe
 
   livenessProbe:
@@ -720,7 +720,7 @@ webhook:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
+  # here you can override the readinessProbe for the webhook container
   # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:

--- a/README.md
+++ b/README.md
@@ -7,12 +7,9 @@
 > If you're interested in making a difference,
 > [join the discussion](https://github.com/8gears/n8n-helm-chart/discussions/90).
 
-
 # n8n Helm Chart for Kubernetes
 
 [n8n](https://github.com/n8n-io/n8n) is an extendable workflow automation tool.
-
-
 
 The Helm chart source code location is [github.com/8gears/n8n-helm-chart](https://github.com/8gears/n8n-helm-chart)
 
@@ -287,8 +284,21 @@ main:
   #  - -c
   #  - chmod o+rx /root; chown -R node /root/.n8n || true; chown -R node /root/.n8n; ln -s /root/.n8n /home/node; chown -R node /home/node || true; node /usr/local/bin/n8n
 
+  # here you can override the startupProbe for the main container
+  # it may be used to increase the timeout for the startupProbe
+
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    # initialDelaySeconds: 30
+    # periodSeconds: 10
+    # timeoutSeconds: 5
+    # failureThreshold: 6
+    # successThreshold: 1
+
   # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the livenessProbe
 
   livenessProbe:
     httpGet:
@@ -301,7 +311,7 @@ main:
     # successThreshold: 1
 
   # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:
     httpGet:
@@ -483,8 +493,20 @@ worker:
   # command args
   commandArgs: []
 
+  # here you can override the startupProbe for the main container
+  # it may be used to increase the timeout for the startupProbe
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    # initialDelaySeconds: 30
+    # periodSeconds: 10
+    # timeoutSeconds: 5
+    # failureThreshold: 6
+    # successThreshold: 1
+
   # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the livenessProbe
   livenessProbe:
     httpGet:
       path: /healthz
@@ -496,7 +518,7 @@ worker:
     # successThreshold: 1
 
   # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:
     httpGet:
@@ -672,8 +694,21 @@ webhook:
   # Command Arguments
   commandArgs: []
 
+  # here you can override the startupProbe for the main container
+  # it may be used to increase the timeout for the startupProbe
+
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    # initialDelaySeconds: 30
+    # periodSeconds: 10
+    # timeoutSeconds: 5
+    # failureThreshold: 6
+    # successThreshold: 1
+
   # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the livenessProbe
 
   livenessProbe:
     httpGet:
@@ -686,7 +721,7 @@ webhook:
     # successThreshold: 1
 
   # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:
     httpGet:
@@ -782,14 +817,15 @@ valkey:
   #    existingClaim: ""
   #    size: 2Gi
 ```
+
 ## Migration Guide to Version 1.0.0
 
 This version includes a complete redesign of the chart to better accommodate n8n configuration options.
 Key changes include:
+
 - Values restructured under `.Values.main`, `.Values.worker`, and `.Values.webhook`
 - Updated deployment configurations
 - New Redis integration requirements
-
 
 ## Scaling and Advanced Configuration Options
 
@@ -832,4 +868,3 @@ At last scaling option is it possible to create dedicated webhook instances,
 which only process the webhooks.
 If you set `scaling.webhook.enabled=true`, then webhook processing on the main
 instance is disabled and by default a single webhook instance is started.
-

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.1.0
+version: 1.2.0
 appVersion: 1.116.2
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -76,6 +76,10 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.webhook.config.n8n) "port" | default 5678 }}
               protocol: TCP
+          {{- with .Values.webhook.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.webhook.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -99,6 +99,10 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.worker.config.n8n) "port" | default 5678 }}
               protocol: TCP
+          {{- with .Values.worker.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.worker.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -84,12 +84,12 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.main.config.n8n) "port" | default 5678 }}
               protocol: TCP
-          {{- with .Values.main.livenessProbe }}
-          livenessProbe:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
           {{- with .Values.main.startupProbe }}
           startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.main.livenessProbe }}
+          livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- with .Values.main.readinessProbe }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
           livenessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.main.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.main.readinessProbe }}
           readinessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -197,8 +197,21 @@ main:
   #  - -c
   #  - chmod o+rx /root; chown -R node /root/.n8n || true; chown -R node /root/.n8n; ln -s /root/.n8n /home/node; chown -R node /home/node || true; node /usr/local/bin/n8n
 
+  # here you can override the startupProbe for the main container
+  # it may be used to increase the timeout for the startupProbe
+
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    # initialDelaySeconds: 30
+    # periodSeconds: 10
+    # timeoutSeconds: 5
+    # failureThreshold: 6
+    # successThreshold: 1
+
   # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the livenessProbe
 
   livenessProbe:
     httpGet:
@@ -211,7 +224,7 @@ main:
     # successThreshold: 1
 
   # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:
     httpGet:
@@ -394,8 +407,20 @@ worker:
   # command args
   commandArgs: []
 
+  # here you can override the startupProbe for the main container
+  # it may be used to increase the timeout for the startupProbe
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    # initialDelaySeconds: 30
+    # periodSeconds: 10
+    # timeoutSeconds: 5
+    # failureThreshold: 6
+    # successThreshold: 1
+
   # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the livenessProbe
   livenessProbe:
     httpGet:
       path: /healthz
@@ -407,7 +432,7 @@ worker:
     # successThreshold: 1
 
   # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:
     httpGet:
@@ -583,8 +608,21 @@ webhook:
   # Command Arguments
   commandArgs: []
 
+  # here you can override the startupProbe for the main container
+  # it may be used to increase the timeout for the startupProbe
+
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    # initialDelaySeconds: 30
+    # periodSeconds: 10
+    # timeoutSeconds: 5
+    # failureThreshold: 6
+    # successThreshold: 1
+
   # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the livenessProbe
 
   livenessProbe:
     httpGet:
@@ -597,7 +635,7 @@ webhook:
     # successThreshold: 1
 
   # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
+  # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:
     httpGet:

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -407,7 +407,7 @@ worker:
   # command args
   commandArgs: []
 
-  # here you can override the startupProbe for the main container
+  # here you can override the startupProbe for the worker container
   # it may be used to increase the timeout for the startupProbe
   startupProbe:
     httpGet:
@@ -419,7 +419,7 @@ worker:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the livenessProbe for the main container
+  # here you can override the livenessProbe for the worker container
   # it may be used to increase the timeout for the livenessProbe
   livenessProbe:
     httpGet:
@@ -431,7 +431,7 @@ worker:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
+  # here you can override the readinessProbe for the worker container
   # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:
@@ -608,7 +608,7 @@ webhook:
   # Command Arguments
   commandArgs: []
 
-  # here you can override the startupProbe for the main container
+  # here you can override the startupProbe for the webhook container
   # it may be used to increase the timeout for the startupProbe
 
   startupProbe:
@@ -621,7 +621,7 @@ webhook:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the livenessProbe for the main container
+  # here you can override the livenessProbe for the webhook container
   # it may be used to increase the timeout for the livenessProbe
 
   livenessProbe:
@@ -634,7 +634,7 @@ webhook:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
+  # here you can override the readinessProbe for the webhook container
   # it may be used to increase the timeout for the readinessProbe
 
   readinessProbe:


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds the possibility to add and configure `startupProbes` for each container 

## Which issue this PR fixes

It will allow to configure probes according to this recommendation: https://github.com/n8n-io/n8n/issues/17190#issuecomment-3242565131

And therefore avoid DB connection issues.

## Special notes for your reviewer

<!-- Any additional context, special considerations, or things reviewers should pay attention to -->

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [ ] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [x] Variables are documented in the `README.md`
### Testing and Validation
- [ ] Ran `ah lint` locally without errors
- [ ] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [ ] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional startup probe support added for main, worker, and webhook containers to improve initialization health checks.

* **Documentation**
  * Added comprehensive startup probe examples, standardized probe comments, and adjusted wording for liveness/readiness guidance.
  * Migration Guide updated to Version 1.0.0 format and overall readability improved.

* **Chores**
  * Helm chart version bumped to 1.2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->