### PR TITLE
feat: add form-waiting and form-test paths to ingress routing

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,5 +34,5 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"
+    - kind: added
+      description: "Add form-waiting and form-test paths to ingress routing"

--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -68,6 +68,20 @@ spec:
                 name: {{ $fullName }}-webhook
                 port:
                   number: {{ $.Values.webhook.service.port | default 80  }}
+          - path: {{ trimSuffix "/" .path }}/form-waiting/
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}-webhook
+                port:
+                  number: {{ $.Values.webhook.service.port | default 80  }}
+          - path: {{ trimSuffix "/" .path }}/form-test/
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $.Values.main.service.port | default 80  }}
           {{- end }}
           {{- end }}
     {{- end }}


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds support for n8n's form functionality by adding two new ingress paths to the Helm chart:
- `form-waiting/` routes to the webhook service for handling form submissions in waiting state
- `form-test/` routes to the main service for form testing

These paths are essential for n8n's form to work properly.

## Special notes for your reviewer

The routing logic follows the existing pattern in the ingress template:
- Form submissions in waiting state need to be handled by the webhook service (similar to existing `form/` and `webhook-waiting/` paths)
- Form test workflows should be routed to the main service (similar to existing `webhook-test/` path)

This change is backward compatible and only adds new functionality when the webhook service is enabled.

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [ ] App version updated in `Chart.yaml` if applicable
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [ ] Variables are documented in the `README.md`
### Testing and Validation
- [x] Ran `ah lint` locally without errors
- [x] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [ ] Tested with example configurations in `/examples` directory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ingress routes for form-waiting and form-test endpoints to enable direct access through the ingress controller.

* **Version**
  * Chart version updated to 2.0.2.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->