### PR TITLE
[#251] Removed hardcoded pathType: Prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ ingress:
   hosts:
     - host: workflow.example.com
       paths: []
+      #  - path: /
+      #    pathType: Prefix
   tls:
     - hosts:
         - workflow.example.com

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.0
+version: 2.0.1
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -35,6 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "BREAKING CHANGE: Replace Bitnami Valkey dependency with official Valkey Helm chart from valkey.io"
-    - kind: changed
-      description: "update n8n to version 1.122.4"
+      description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"

--- a/charts/n8n/templates/NOTES.txt
+++ b/charts/n8n/templates/NOTES.txt
@@ -2,7 +2,7 @@
 {{- if .Values.ingress.enabled }}
 {{- range $host := .Values.ingress.hosts }}
   {{- range .paths }}
-  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ . }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" (default "ClusterIP" .Values.main.service.type) }}

--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -31,38 +31,38 @@ spec:
       http:
         paths:
           {{- range .paths }}
-          - path: {{ . }}
-            pathType: Prefix
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $.Values.main.service.port | default 80  }}
           {{- if $.Values.webhook.enabled }}
-          - path: {{ . }}webhook/
-            pathType: Prefix
+          - path: {{ trimSuffix "/" .path }}/webhook/
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ $fullName }}-webhook
                 port:
                   number: {{ $.Values.webhook.service.port | default 80  }}
           # Note: The default URL for manual workflow executions is /webhook-test/*. Make sure that these URLs route to your main process.
-          - path: {{ . }}webhook-test/
-            pathType: Prefix
+          - path: {{ trimSuffix "/" .path }}/webhook-test/
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $.Values.main.service.port  | default 80  }}
-          - path: {{ . }}webhook-waiting/
-            pathType: Prefix
+          - path: {{ trimSuffix "/" .path }}/webhook-waiting/
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ $fullName }}-webhook
                 port:
                   number: {{ $.Values.webhook.service.port | default 80  }}
-          - path: {{ . }}form/
-            pathType: Prefix
+          - path: {{ trimSuffix "/" .path }}/form/
+            pathType: {{ .pathType }}
             backend:
               service:
                 name: {{ $fullName }}-webhook

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -39,7 +39,9 @@ ingress:
   className: ""
   hosts:
     - host: workflow.example.com
-      paths: []
+      paths:
+        - path: /
+          pathType: Prefix
   tls: []
     # - hosts:
     #    - workflow.example.com

--- a/examples/values_full.yaml
+++ b/examples/values_full.yaml
@@ -103,7 +103,8 @@ ingress:
   hosts:
     - host: *hostname
       paths:
-        - /
+        - path: /
+          pathType: Prefix
   tls:
     - secretName: n8n-ingress-tls
       hosts:

--- a/examples/values_small_prod.yaml
+++ b/examples/values_small_prod.yaml
@@ -60,7 +60,8 @@ ingress:
   hosts:
     - host: n8n-dev.8gears.com
       paths:
-        - /
+        - path: /
+          pathType: Prefix
   tls:
     - secretName: n8n-ingress-tls
       hosts:


### PR DESCRIPTION
Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'

## What this PR does / why we need it

In the current version, the pathType elements in the ingress object are hardcoded to `pathType: Prefix`.
This PR aligns the chart to the best practices, allowing to define a different type of pathType, as `Prefix` might be incompatible with some ingress controllers.

## Which issue this PR fixes

Fixes #251

## Special notes for your reviewer

<!-- Any additional context, special considerations, or things reviewers should pay attention to -->

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [ ] App version updated in `Chart.yaml` if applicable
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [x] Variables are documented in the `README.md`
### Testing and Validation
- [x] Ran `ah lint` locally without errors
- [x] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [x] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ingress routing now accepts explicit path objects with configurable pathType; webhook and form URLs are composed from the configured path for consistent URL behavior.

* **Chores**
  * Chart version bumped to 2.0.1.

* **Documentation**
  * README updated with commented example lines showing ingress path and pathType usage.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->