### PR TITLE
Fix chart behaviour when Redis/Valkey Cluster is used

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 1.1.0
+version: 1.1.1
 appVersion: 1.116.2
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -97,9 +97,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{/* Validate Valkey/Redis configuration when webhooks are enabled*/}}
 {{- define "n8n.validateValkey" -}}
 {{- $envVars := fromYaml (include "toEnvVars" (dict "values" .Values.main.config "prefix" "")) -}}
-{{- if and .Values.webhook.enabled (not $envVars.QUEUE_BULL_REDIS_HOST) -}}
+{{- if and .Values.webhook.enabled (not $envVars.QUEUE_BULL_REDIS_HOST) (not $envVars.QUEUE_BULL_REDIS_CLUSTER_NODES) -}}
 {{- fail "Webhook processes rely on Valkey. Please set a Redis/Valkey host when webhook.enabled=true" -}}
 {{- end -}}
 {{- end -}}
-
-


### PR DESCRIPTION
## What this PR does / why we need it

When using Redis/Valkey Cluster instead of standalone (for HA purposes), the chart throws an error because the `QUEUE_BULL_REDIS_HOST` environnement variable stays empty, while `QUEUE_BULL_REDIS_CLUSTER_NODES` is not.

Ref.: https://docs.n8n.io/hosting/configuration/environment-variables/queue-mode/



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Redis/Valkey validation for webhook configurations to ensure both host and cluster nodes are validated when webhooks are enabled.

* **Chores**
  * Updated chart version to 1.1.1.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->