### PR TITLE
feat(httproute): add ingress sucessor manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ The `values.yaml` file is divided into multiple sections (global, n8n, and Kuber
 Use this structure to orient yourself.
 
 1. Global and chart wide values, like the image repository, image tag, etc.
-2. Ingress, (default is nginx, but you can change it to your own ingress controller)
-3. Main n8n app configuration + Kubernetes specific settings
-4. Worker related settings + Kubernetes specific settings
-5. Webhook related settings + Kubernetes specific settings
-6. Raw Resources to pass through your own manifests like GatewayAPI, ServiceMonitor etc.
-7. Redis related settings + Kubernetes specific settings
+2. HttpRoute
+3. Ingress, (default is nginx, but you can change it to your own ingress controller)
+4. Main n8n app configuration + Kubernetes specific settings
+5. Worker related settings + Kubernetes specific settings
+6. Webhook related settings + Kubernetes specific settings
+7. Raw Resources to pass through your own manifests like GatewayAPI, ServiceMonitor etc.
+8. Redis related settings + Kubernetes specific settings
 
 ## Configurating N8n via Values and Environment Variables
 
@@ -124,6 +125,44 @@ hostAliases: []
   #- ip: 8.8.8.8
   #  hostnames:
 #    - service-example.local
+#
+# HTTPRoute
+#
+route:
+  # -- enable an HTTPRoute resource for n8n server
+  enabled: false
+  # -- Set the route apiVersion
+  apiVersion: gateway.networking.k8s.io/v1
+  # -- Set the route kind
+  kind: HTTPRoute
+  hostnames:
+    - workflow.example.com
+  # -- Reference to parent gateways
+  parentRefs:
+    - name: traefik-gateway
+      namespace: traefik
+      sectionName: websecure
+  main:
+    # -- Route matches
+    matches:
+      - path:
+          type: PathPrefix
+          value: "/"
+  webhook:
+    # -- Route matches
+    matches:
+      - path:
+          type: PathPrefix
+          value: /webhook/
+      - path:
+          type: PathPrefix
+          value: /webhook-test/
+      - path:
+          type: PathPrefix
+          value: /webhook-waiting/
+      - path:
+          type: PathPrefix
+          value: /form
 #
 # Ingress
 #

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
+version: 2.1.0
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,5 +34,5 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"
+    - kind: added
+      description: "Add HTTPRoute manifest for server and webhook"

--- a/charts/n8n/templates/route.yaml
+++ b/charts/n8n/templates/route.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.route.enabled }}
+{{- $fullName := include "n8n.fullname" . -}}
+apiVersion: {{ .Values.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ .Values.route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+    {{- with .Values.route.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- if .Values.route.additionalRules }}
+    {{- tpl (toYaml .Values.route.additionalRules) $ | nindent 4 }}
+    {{- end }}
+    - backendRefs:
+        - name: {{ $fullName }}
+          port: {{ $.Values.main.service.port | default 80  }}
+      {{- with .Values.route.main.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.route.main.matches }}
+      matches:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+    {{- if $.Values.webhook.enabled }}
+    - backendRefs:
+        - name: {{ $fullName }}-webhook
+          port: {{ $.Values.webhook.service.port | default 80  }}
+      {{- with .Values.route.webhook.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.route.webhook.matches }}
+      matches:
+        {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -47,6 +47,54 @@ ingress:
     #    - workflow.example.com
     #  secretName: host-domain-cert
 
+#
+# HTTPRoute
+#
+route:
+  # -- enable an HTTPRoute resource for n8n server
+  enabled: false
+  # -- Set the route apiVersion
+  apiVersion: gateway.networking.k8s.io/v1
+  # -- Set the route kind
+  kind: HTTPRoute
+  # -- Route annotations
+  annotations: {}
+  # -- Route labels
+  labels: {}
+  # -- Route hostnames
+  hostnames: []
+  # -- Reference to parent gateways
+  parentRefs: []
+  # -- Additional rules  to deny some path like ingresses
+  additionalRules: []
+  main:
+    # -- Route matches
+    matches:
+      - path:
+          type: PathPrefix
+          value: "/"
+    # -- Route filters
+    filters: []
+    # -- Additional rules  to deny some path like ingresses
+    additionalRules: []
+  webhook:
+    # -- Route matches
+    matches:
+      - path:
+          type: PathPrefix
+          value: /webhook/
+      - path:
+          type: PathPrefix
+          value: /webhook-test/
+      - path:
+          type: PathPrefix
+          value: /webhook-waiting/
+      - path:
+          type: PathPrefix
+          value: /form
+    # -- Route filters
+    filters: []
+
 # the main (n8n) application related configuration + Kubernetes specific settings
 # The config: {} dictionary is converted to environmental variables in the ConfigMap.
 main:


### PR DESCRIPTION
## What this PR does / why we need it

add template/manifest for `kind: HTTPRoute` sucessor of ` kind: Ingress` , because is now in GA, for both n8n server & webhook, following quite the same logic as `Ingress` 

## Which issue this PR fixes

can create one if needed ..

## Special notes for your reviewer

tested manually

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
~~- [ ] App version updated in `Chart.yaml` if applicable~~
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [x] Variables are documented in the `README.md`
### Testing and Validation
- [x] Ran `ah lint` locally without errors
- [x] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [x] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTPRoute support to configure network routing for the server and webhook endpoints, including configurable hosts, rules, matches, filters and parent references.

* **Documentation**
  * Expanded README with HTTPRoute configuration examples and reordered configuration overview to include the new route section.

* **Chores**
  * Bumped chart version to 2.1.0 to release the new routing options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->