### PR TITLE
fix: update PVC configuration for worker and webhook pods to prevent …

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,8 @@ worker:
   # Worker Kubernetes specific settings
   #
   persistence:
+    # Worker pods use their own volume and do not reuse the main PVC by default to avoid RWO multi-attach issues.
+    # If you want workers to share storage with main, point existingClaim to the main PVC name explicitly.
     # If true, use a Persistent Volume Claim, If false, use emptyDir
     enabled: false
     # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
@@ -581,6 +583,8 @@ webhook:
   # Webhook Kubernetes specific settings
   #
   persistence:
+    # Webhook pods use their own volume and do not reuse the main PVC by default to avoid RWO multi-attach issues.
+    # If you need them to share storage with main, set existingClaim to the main PVC name explicitly.
     # If true, use a Persistent Volume Claim, If false, use emptyDir
     enabled: false
     # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
@@ -847,4 +851,3 @@ At last scaling option is it possible to create dedicated webhook instances,
 which only process the webhooks.
 If you set `scaling.webhook.enabled=true`, then webhook processing on the main
 instance is disabled and by default a single webhook instance is started.
-

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,5 +34,5 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"
+    - kind: fixed
+      description: "Workers and webhooks now use their own PVC configuration instead of always mounting the main PVC, preventing RWO multi-attach issues"

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -62,14 +62,17 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* PVC existing, emptyDir, Dynamic */}}
 {{- define "n8n.pvc" -}}
-{{- if or (not .Values.main.persistence.enabled) (eq .Values.main.persistence.type "emptyDir") -}}
+{{- $persistence := .persistence -}}
+{{- $root := .root -}}
+{{- $claimName := default (include "n8n.fullname" $root) .claimName -}}
+{{- if or (not $persistence.enabled) (eq $persistence.type "emptyDir") -}}
           emptyDir: {}
-{{- else if and .Values.main.persistence.enabled .Values.main.persistence.existingClaim -}}
+{{- else if and $persistence.enabled $persistence.existingClaim -}}
           persistentVolumeClaim:
-            claimName: {{ .Values.main.persistence.existingClaim }}
-{{- else if and .Values.main.persistence.enabled (eq .Values.main.persistence.type "dynamic")  -}}
+            claimName: {{ $persistence.existingClaim }}
+{{- else if and $persistence.enabled (eq $persistence.type "dynamic")  -}}
           persistentVolumeClaim:
-            claimName: {{ include "n8n.fullname" . }}
+            claimName: {{ $claimName }}
 {{- end }}
 {{- end }}
 
@@ -101,5 +104,4 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- fail "Webhook processes rely on Valkey. Please set a Redis/Valkey host when webhook.enabled=true" -}}
 {{- end -}}
 {{- end -}}
-
 

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -140,7 +140,7 @@ spec:
       {{- end }}
       volumes:
         - name: "data"
-          {{ include "n8n.pvc" . }}
+          {{ include "n8n.pvc" (dict "root" . "persistence" .Values.webhook.persistence "claimName" (printf "%s-webhook" (include "n8n.fullname" .))) }}
         {{- if .Values.webhook.extraVolumes }}
           {{- toYaml .Values.webhook.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -136,7 +136,7 @@ spec:
       {{- end }}
       volumes:
         - name: "data"
-          {{ include "n8n.pvc" . }}
+          {{ include "n8n.pvc" (dict "root" . "persistence" .Values.worker.persistence "claimName" (printf "%s-worker" (include "n8n.fullname" .))) }}
         {{- if .Values.worker.extraVolumes }}
           {{- toYaml .Values.worker.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -121,7 +121,7 @@ spec:
       {{- end }}
       volumes:
         - name: "data"
-          {{ include "n8n.pvc" . }}
+          {{ include "n8n.pvc" (dict "root" . "persistence" .Values.main.persistence) }}
         {{- if .Values.main.extraVolumes }}
           {{- toYaml .Values.main.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/pvc.webhook.yaml
+++ b/charts/n8n/templates/pvc.webhook.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.webhook.enabled .Values.webhook.persistence.enabled (not .Values.webhook.persistence.existingClaim) (eq .Values.webhook.persistence.type "dynamic") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "n8n.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.webhook.persistence.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- range .Values.webhook.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.webhook.persistence.size }}
+  {{- if .Values.webhook.persistence.storageClass }}
+  {{- if eq "-" .Values.webhook.persistence.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.webhook.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/n8n/templates/pvc.worker.yaml
+++ b/charts/n8n/templates/pvc.worker.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.worker.enabled .Values.worker.persistence.enabled (not .Values.worker.persistence.existingClaim) (eq .Values.worker.persistence.type "dynamic") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "n8n.fullname" . }}-worker
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.worker.persistence.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- range .Values.worker.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.worker.persistence.size }}
+  {{- if .Values.worker.persistence.storageClass }}
+  {{- if eq "-" .Values.worker.persistence.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ .Values.worker.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -294,6 +294,8 @@ worker:
   # Worker Kubernetes specific settings
   #
   persistence:
+    # Worker pods use their own volume and do not reuse the main PVC by default to avoid RWO multi-attach issues.
+    # If you want workers to share storage with main, point existingClaim to the main PVC name explicitly.
     # If true, use a Persistent Volume Claim, If false, use emptyDir
     enabled: false
     # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
@@ -480,6 +482,8 @@ webhook:
   # Webhook Kubernetes specific settings
   #
   persistence:
+    # Webhook pods use their own volume and do not reuse the main PVC by default to avoid RWO multi-attach issues.
+    # If you need them to share storage with main, set existingClaim to the main PVC name explicitly.
     # If true, use a Persistent Volume Claim, If false, use emptyDir
     enabled: false
     # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim


### PR DESCRIPTION
…RWO multi-attach issues

Stopped worker/webhook from auto-mounting the main PVC and added component-specific claims so RWO volumes no longer hit multi-attach errors.

-_helpers.tpl: pvc helper now takes an explicit persistence context/claim so each component mounts its own volume.
-deployment.yaml, deployment.worker.yaml, deployment.webhook.yaml: pass component persistence configs; worker/webhook use suffix-specific claim names and default to their own emptyDir unless configured otherwise.
- pvc.worker.yaml, pvc.webhook.yaml: create dedicated PVCs when worker/webhook persistence is enabled with dynamic provisioning.
- values.yaml, README.md: note that worker/webhook storage is separate by default and how to point existingClaim at the main PVC if you really want to share it.
- Chart.yaml: bump chart version to 2.0.2 with an artifacthub change note about the PVC fix.

## What this PR does / why we need it

Fixes RWO multi-attach errors by stopping worker/webhook from auto-mounting the main PVC and giving each component its own persistence wiring/claims.
Adds component-specific PVC templates and updates mounts to use per-component claims (or an explicitly provided existingClaim).
Documents the new defaults and bumps the chart to 2.0.2 with an ArtifactHub entry describing the fix.
## Which issue this PR fixes

## Which issue this PR fixes
fixes #280 

## Special notes for your reviewer

<!-- Any additional context, special considerations, or things reviewers should pay attention to -->

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [ ] App version updated in `Chart.yaml` if applicable
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [x] Variables are documented in the `README.md`
### Testing and Validation
- [X] Ran `ah lint` locally without errors
- [X] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [x] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RWO multi-attach issues by configuring workers and webhooks with their own persistent volume claims by default.

* **Documentation**
  * Added guidance on storage configuration for workers and webhooks, including instructions for sharing storage with the main component when needed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->