### PR TITLE
feat: Add HPA for Autoscaling Webhook and Workers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,10 @@
 7. The maintainers create a new release in GitHub using the chart version number as the tag and title.
 
 
+## Commit Messages
+Make sure your commit messages follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) style
+
+
 ## Chart Versioning Schema
 
 The versions of the chart follow this schema:

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
+version: 2.1.0
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,5 +34,5 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"
+    - kind: added
+      description: "HPA support for autoscaling workers and webhooks"

--- a/charts/n8n/templates/hpa.webhook.yaml
+++ b/charts/n8n/templates/hpa.webhook.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.webhook.autoscaling.enabled }}
+{{- if and .Values.webhook .Values.webhook.autoscaling .Values.webhook.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/n8n/templates/hpa.webhook.yaml
+++ b/charts/n8n/templates/hpa.webhook.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.webhook.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "n8n.fullname" . }}-webhook
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "n8n.fullname" . }}-webhook
+  minReplicas: {{ .Values.webhook.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.webhook.autoscaling.maxReplicas | default 100 }}
+  {{- if or .Values.webhook.autoscaling.targetCPUUtilizationPercentage .Values.webhook.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.webhook.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.webhook.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.webhook.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.webhook.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/n8n/templates/hpa.worker.yaml
+++ b/charts/n8n/templates/hpa.worker.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.worker.autoscaling.enabled }}
+{{- if and .Values.worker .Values.worker.autoscaling .Values.worker.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/n8n/templates/hpa.worker.yaml
+++ b/charts/n8n/templates/hpa.worker.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.worker.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "n8n.fullname" . }}-worker
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "n8n.fullname" . }}-worker
+  minReplicas: {{ .Values.worker.autoscaling.minReplicas | default 1 }}
+  maxReplicas: {{ .Values.worker.autoscaling.maxReplicas | default 100 }}
+  {{- if or .Values.worker.autoscaling.targetCPUUtilizationPercentage .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+  metrics:
+    {{- if .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -434,10 +434,11 @@ worker:
     port: 80
 
   resources: {}
-  # We usually recommend not specifying default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # Unless you are autoscaling, we usually recommend not specifying default resources and
+  # to leave this as a conscious choice for the user. This also increases chances charts run
+  # on environments with little resources, such as Minikube. If you do want to specify
+  # resources, uncomment the following lines, adjust them as necessary, and remove the curly
+  # braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -449,6 +450,9 @@ worker:
     enabled: false
     minReplicas: 1
     maxReplicas: 100
+    # If you use targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage, you
+    # **MUST** set the requests for the relevant resource. (i.e. if you set a value for
+    # targetCPUUtilizationPercentage, you **MUST** set a value for resources.requests.cpu)
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
 
@@ -624,10 +628,11 @@ webhook:
     port: 80
 
   resources: {}
-  # We usually recommend not specifying default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # Unless you are autoscaling, we usually recommend not specifying default resources and
+  # to leave this as a conscious choice for the user. This also increases chances charts run
+  # on environments with little resources, such as Minikube. If you do want to specify
+  # resources, uncomment the following lines, adjust them as necessary, and remove the curly
+  # braces after 'resources:'.
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -638,6 +643,9 @@ webhook:
     enabled: false
     minReplicas: 1
     maxReplicas: 100
+    # If you use targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage, you
+    # **MUST** set the requests for the relevant resource. (i.e. if you set a value for
+    # targetCPUUtilizationPercentage, you **MUST** set a value for resources.requests.cpu)
     targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
   nodeSelector: {}


### PR DESCRIPTION
## What this PR does / why we need it

<!-- Provide a clear and concise description of what this PR accomplishes and why it's needed -->
This PR introduces support for Horizontal Pod Autoscalers (HPA) for both the `webhook` and `worker` components in the Helm chart.

Fixes issue https://github.com/8gears/n8n-helm-chart/issues/179

## Special notes for your reviewer

<!-- Any additional context, special considerations, or things reviewers should pay attention to -->
Based on PR #186 by @simonefrancia, just implements the fixes requested in there, just trying to get this over the finish line. 
Per that PR (text copied from @simonefrancia's PR):

🆕 Changes Introduced
* Added a new template:
  `charts/n8n/templates/hpa.webhook.yaml`
  Defines an HPA resource for the webhook deployment, conditionally created based on .Values.webhook.autoscaling.enabled.

* Added a new template:
  `charts/n8n/templates/hpa.worker.yaml`
  Defines an HPA resource for the worker deployment, conditionally created based on .Values.worker.autoscaling.enabled.

⚙️ Configuration
Each HPA supports:

* minReplicas
* maxReplicas
* CPU utilization threshold (targetCPUUtilizationPercentage)
* Memory utilization threshold (targetMemoryUtilizationPercentage)

These values are configurable via:

```yaml
webhook:
  autoscaling:
    enabled: true
    minReplicas: 1
    maxReplicas: 5
    targetCPUUtilizationPercentage: 80
    targetMemoryUtilizationPercentage: 75

worker:
  autoscaling:
    enabled: true
    minReplicas: 1
    maxReplicas: 5
    targetCPUUtilizationPercentage: 80
    targetMemoryUtilizationPercentage: 75
```

🧪 Notes
* The HPA definitions are optional and only deployed if enabled in values.
* This enhances scalability and resource efficiency for webhook and worker components.

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Horizontal Pod Autoscaler support for workers and webhooks with optional CPU- and memory-based scaling; metrics only emitted when targets are set.
  * Configurable min/max replicas and per-component toggles for autoscaling.

* **Chores**
  * Chart version bumped to 2.1.0 and release metadata updated.

* **Documentation**
  * CONTRIBUTING: added commit message guidance; values docs clarified autoscaling/resource requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->