### PR TITLE
feat: Add support for custom runner images (n8n v2 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,15 @@ related to the application deployment and operation but not the application itse
 worker:
   enabled: false
 
+  # Worker/Task Runner specific image configuration (for n8n v2+)
+  # For n8n v2.0+, you must use the separate task runner image: n8nio/runners
+  # For n8n v1.x, leave these empty to use the main n8n image.
+  # See: https://docs.n8n.io/2-0-breaking-changes/#remove-task-runner-from-n8nion8n-docker-image
+  image:
+    repository: ""  # Defaults to .Values.image.repository if empty
+    tag: ""         # Defaults to .Values.image.tag if empty
+    pullPolicy: ""  # Defaults to .Values.image.pullPolicy if empty
+
   # additional (to main) config for worker
   config: {}
 
@@ -805,6 +814,41 @@ Key changes include:
 - Updated deployment configurations
 - New Redis integration requirements
 
+## n8n v2.0+ Support and Task Runner Image
+
+Starting with n8n v2.0, the task runner (worker) functionality has been moved to a separate Docker image (`n8nio/runners`). This chart now supports configuring a custom image for workers while maintaining full backwards compatibility with n8n v1.x.
+
+### For n8n v1.x Users (Current Default)
+
+No changes needed! Workers will continue using the main n8n image (`n8nio/n8n`).
+
+### For n8n v2.0+ Users
+
+When upgrading to n8n v2.0 or later, you **must** configure the worker to use the separate task runner image:
+
+```yaml
+image:
+  repository: n8nio/n8n
+  tag: "2.0.0"
+
+worker:
+  enabled: true
+  image:
+    repository: n8nio/runners
+    tag: "2.0.0"
+  # IMPORTANT: Do NOT set command or commandArgs when using n8nio/runners
+  # The runners image has its own launcher and doesn't use "n8n worker" commands
+```
+
+**Key points:**
+- The main n8n application continues to use `n8nio/n8n`
+- Workers/task runners must use `n8nio/runners` for n8n v2.0+
+- **Do not set `worker.command` or `worker.commandArgs`** when using the runners image - it has its own entrypoint/launcher
+- The chart automatically omits command/args when a custom worker image is specified
+- If `worker.image.*` is not specified, it defaults to the global `image.*` configuration (backwards compatible)
+- You can specify different tags for main and worker if needed
+
+For more details, see the [n8n v2.0 breaking changes documentation](https://docs.n8n.io/2-0-breaking-changes/#remove-task-runner-from-n8nion8n-docker-image).
 
 ## Scaling and Advanced Configuration Options
 

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
+version: 2.1.0
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,5 +34,7 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
+    - kind: added
+      description: "Added support for custom worker/task runner image configuration to support n8n v2.0+ separate task runner image (n8nio/runners) while maintaining backwards compatibility with v1.x"
     - kind: changed
       description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -57,8 +57,8 @@ spec:
         - name: {{ .Chart.Name }}-worker
           securityContext:
             {{- toYaml .Values.worker.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.worker.image.repository | default .Values.image.repository }}:{{ .Values.worker.image.tag | default (.Values.image.tag | default .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy | default .Values.image.pullPolicy }}
           envFrom:
             {{- if .Values.main.config }}
             - configMapRef:
@@ -82,15 +82,21 @@ spec:
               {{- toYaml $value | nindent 14 }}
             {{- end }}
           {{- if .Values.worker.command }}
+          {{- /* User has specified a custom command, use it */ -}}
           command:
             {{- toYaml .Values.worker.command | nindent 12 }}
+          {{- else if .Values.worker.image.repository }}
+          {{- /* Worker is using a custom image (likely n8nio/runners for v2) - don't set command, let image entrypoint run */ -}}
           {{- else }}
+          {{- /* Default to n8n v1 worker command */ -}}
           command: ["n8n"]
           {{- end }}
           {{- if .Values.worker.commandArgs }}
+          {{- /* User has specified custom args, use them */ -}}
           args:
             {{- toYaml .Values.worker.commandArgs | nindent 12 }}
-          {{- else }}
+          {{- else if not .Values.worker.image.repository }}
+          {{- /* Only set default args if using the main n8n image (v1 behavior) */ -}}
           args:
             - "worker"
             - "--concurrency={{ .Values.worker.concurrency }}"

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -278,6 +278,24 @@ main:
 worker:
   enabled: false
 
+  # Worker/Task Runner specific image configuration (for n8n v2+)
+  # If not specified, defaults to the global image configuration above.
+  # For n8n v2.0+, you should use the separate task runner image: n8nio/runners
+  # For n8n v1.x, leave these empty to use the main n8n image.
+  # See: https://docs.n8n.io/2-0-breaking-changes/#remove-task-runner-from-n8nion8n-docker-image
+  #
+  # IMPORTANT: When using n8nio/runners image, do NOT set command/commandArgs below.
+  # The runners image has its own launcher and doesn't use the "n8n worker" command.
+  # The chart will automatically omit command/args when a custom image is specified.
+  image:
+    # For n8n v2+, set to n8nio/runners
+    # If empty, defaults to .Values.image.repository (n8nio/n8n)
+    repository: ""
+    # If empty, defaults to .Values.image.tag or Chart.AppVersion
+    tag: ""
+    # If empty, defaults to .Values.image.pullPolicy
+    pullPolicy: ""
+
   # additional (to main) config for worker
   config: {}
 
@@ -381,19 +399,15 @@ worker:
   #      command: ["/bin/sh", "-c", "apk add mysql-client"]
 
   # here you can override a command for worker container
-  # it may be used to override a starting script (e.g., to resolve issues like https://github.com/n8n-io/n8n/issues/6412) or
-  # run additional preparation steps (e.g., installing additional software)
+  # IMPORTANT: When using n8nio/runners (n8n v2), do NOT set this. The runners image
+  # has its own launcher. Only set this for custom configurations.
+  # For n8n v1 workers, the default is ["n8n"] which is set automatically.
   command: []
 
-  # sample configuration that overrides starting script and solves above issue (also it runs n8n as root, so be careful):
-  # command:
-  #  - tini
-  #  - --
-  #  - /bin/sh
-  #  - -c
-  #  - chmod o+rx /root; chown -R node /root/.n8n || true; chown -R node /root/.n8n; ln -s /root/.n8n /home/node; chown -R node /home/node || true; node /usr/local/bin/n8n
-
   # command args
+  # IMPORTANT: When using n8nio/runners (n8n v2), do NOT set this. The runners image
+  # manages its own process. Only set this for custom configurations.
+  # For n8n v1 workers, the default is ["worker", "--concurrency=X"] which is set automatically.
   commandArgs: []
 
   # here you can override the livenessProbe for the main container

--- a/examples/values_full.yaml
+++ b/examples/values_full.yaml
@@ -68,6 +68,14 @@ main:
 
 worker:
   enabled: true
+  # For n8n v2.0+, you must use the separate task runner image
+  # Uncomment the following lines when upgrading to n8n v2.0+:
+  # image:
+  #   repository: n8nio/runners
+  #   tag: 2.0.0
+  # IMPORTANT: Do NOT set command or commandArgs when using n8nio/runners
+  # The runners image has its own launcher and doesn't accept "n8n worker" commands
+  # See: https://docs.n8n.io/2-0-breaking-changes/#remove-task-runner-from-n8nion8n-docker-image
   extraEnv: *extraEnv # using YAML magic (anchors) to reference main extraEnv
   extraVolumeMounts: *extraVolumeMounts # using YAML magic (anchors) to reference main extraVolumeMounts
   extraVolumes: *extraVolumes # using YAML magic (anchors) to reference main extraVolumes


### PR DESCRIPTION
## What this PR does / why we need it

This PR adds support for configuring a separate Docker image for n8n workers/task runners, enabling compatibility with n8n v2.0+ while maintaining full backwards compatibility with v1.x deployments.

### Background

Starting with n8n v2.0, the task runner functionality has been removed from the main n8nio/n8n Docker image and moved to a separate n8nio/runners image. This is a breaking change that requires users to configure workers to use the new image.
See: https://docs.n8n.io/2-0-breaking-changes/#remove-task-runner-from-n8nion8n-docker-image

## Which issue this PR fixes
Fixes #281.

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [x] App version updated in `Chart.yaml` if applicable
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [x] Variables are documented in the `README.md`
### Testing and Validation
- [ ] Ran `ah lint` locally without errors
- [ ] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [ ] Tested chart installation locally
- [ ] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Configure a separate worker/task-runner image with repository, tag and pull policy, defaulting to main image when unset; chart omits command/args for the dedicated runners image to preserve its entrypoint.

* **Chores**
  - Helm chart version bumped to 2.1.0.

* **Documentation**
  - Added migration guide, README notes and examples for v2.0+ runners image usage, defaults, and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->