### PR TITLE
PLAT-3829-n8n-V2-support

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
-appVersion: 1.122.4
+version: 2.1.0
+appVersion: 2.6.3
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
 home: https://github.com/8gears/n8n-helm-chart
@@ -34,5 +34,7 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
+    - kind: added
+      description: "Added support for custom worker/task runner image configuration to support n8n v2.0+ separate task runner image (n8nio/runners) while maintaining backwards compatibility with v1.x"
     - kind: changed
       description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -57,8 +57,8 @@ spec:
         - name: {{ .Chart.Name }}-worker
           securityContext:
             {{- toYaml .Values.worker.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          image: "{{ .Values.worker.image.repository | default .Values.image.repository }}:{{ .Values.worker.image.tag | default (.Values.image.tag | default .Chart.AppVersion) }}"
+          imagePullPolicy: {{ .Values.worker.image.pullPolicy | default .Values.image.pullPolicy }}
           envFrom:
             {{- if .Values.main.config }}
             - configMapRef:
@@ -81,15 +81,19 @@ spec:
             - name: {{ $key }}
               {{- toYaml $value | nindent 14 }}
             {{- end }}
+          {{- if hasKey .Values.worker "command" }}
           {{- if .Values.worker.command }}
           command:
             {{- toYaml .Values.worker.command | nindent 12 }}
+          {{- end }}
           {{- else }}
           command: ["n8n"]
           {{- end }}
+          {{- if hasKey .Values.worker "commandArgs" }}
           {{- if .Values.worker.commandArgs }}
           args:
             {{- toYaml .Values.worker.commandArgs | nindent 12 }}
+          {{- end }}
           {{- else }}
           args:
             - "worker"

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -84,6 +84,9 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.main.config.n8n) "port" | default 5678 }}
               protocol: TCP
+            - name: task-broker
+              containerPort: 5679
+              protocol: TCP
           {{- with .Values.main.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/service.yaml
+++ b/charts/n8n/templates/service.yaml
@@ -17,6 +17,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: 5679
+      targetPort: 5679
+      protocol: TCP
+      name: task-broker
   selector:
     {{- include "n8n.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/type: master

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -278,6 +278,20 @@ main:
 worker:
   enabled: false
 
+  # Worker/Task Runner specific image configuration (for n8n v2+)
+  # If not specified, defaults to the global image configuration above.
+  # For n8n v2.0+, you should use the separate task runner image: n8nio/runners
+  # For n8n v1.x, leave these empty to use the main n8n image.
+  # See: https://docs.n8n.io/2-0-breaking-changes/#remove-task-runner-from-n8nion8n-docker-image
+  image:
+    # For n8n v2+, set to n8nio/runners
+    # If empty, defaults to .Values.image.repository (n8nio/n8n)
+    repository: ""
+    # If empty, defaults to .Values.image.tag or Chart.AppVersion
+    tag: ""
+    # If empty, defaults to .Values.image.pullPolicy
+    pullPolicy: ""
+
   # additional (to main) config for worker
   config: {}
 
@@ -585,31 +599,27 @@ webhook:
   # Command Arguments
   commandArgs: []
 
-  # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
-
+  # here you can override the livenessProbe for the worker container
+  # For n8n v2+, the runners image exposes health check on port 5680
+  # For n8n v1.x using main image, use port: http (5678)
   livenessProbe:
     httpGet:
       path: /healthz
-      port: http
-    # initialDelaySeconds: 30
-    # periodSeconds: 10
-    # timeoutSeconds: 5
-    # failureThreshold: 6
-    # successThreshold: 1
+      port: 5680  # Runners health check server port (n8n v2+)
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
 
-  # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
-
+  # here you can override the readinessProbe for the worker container
   readinessProbe:
     httpGet:
       path: /healthz
-      port: http
-    # initialDelaySeconds: 30
-    # periodSeconds: 10
-    # timeoutSeconds: 5
-    # failureThreshold: 6
-    # successThreshold: 1
+      port: 5680  # Runners health check server port (n8n v2+)
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    timeoutSeconds: 5
+    failureThreshold: 3
 
   # List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started.
   # See https://kubernetes.io/docs/concepts/workloads/pods/init-containers/

--- a/examples/values_full.yaml
+++ b/examples/values_full.yaml
@@ -68,6 +68,35 @@ main:
 
 worker:
   enabled: true
+  # For n8n v2.0+, you must use the separate task runner image
+  # Uncomment the following lines when upgrading to n8n v2.0+:
+  # image:
+  #   repository: n8nio/runners
+  #   tag: 2.6.3
+  #
+  # Override command to use runners image default entrypoint:
+  # command: []
+  # commandArgs: []
+  #
+  # Configure health probes for runners image (health check on port 5680):
+  # livenessProbe:
+  #   httpGet:
+  #     path: /healthz
+  #     port: 5680
+  #   initialDelaySeconds: 10
+  #   periodSeconds: 10
+  #   timeoutSeconds: 5
+  #   failureThreshold: 3
+  # readinessProbe:
+  #   httpGet:
+  #     path: /healthz
+  #     port: 5680
+  #   initialDelaySeconds: 5
+  #   periodSeconds: 5
+  #   timeoutSeconds: 5
+  #   failureThreshold: 3
+  #
+  # See: https://docs.n8n.io/2-0-breaking-changes/#remove-task-runner-from-n8nion8n-docker-image
   extraEnv: *extraEnv # using YAML magic (anchors) to reference main extraEnv
   extraVolumeMounts: *extraVolumeMounts # using YAML magic (anchors) to reference main extraVolumeMounts
   extraVolumes: *extraVolumes # using YAML magic (anchors) to reference main extraVolumes


### PR DESCRIPTION
## What this PR does / why we need it

<!-- Provide a clear and concise description of what this PR accomplishes and why it's needed -->

## Which issue this PR fixes

<!-- Optional: Link related issues using the format below. Issues will be automatically closed when PR is merged -->
<!-- fixes #123, fixes #456 -->

## Special notes for your reviewer

<!-- Any additional context, special considerations, or things reviewers should pay attention to -->

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [ ] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [ ] App version updated in `Chart.yaml` if applicable
- [ ] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [ ] Variables are documented in the `README.md`
### Testing and Validation
- [ ] Ran `ah lint` locally without errors
- [ ] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [ ] Tested chart installation locally
- [ ] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for n8n v2.0+ with configurable separate task runner image
  * Introduced task-broker port (5679) for worker communication
  * New worker-specific image configuration options (repository, tag, pull policy)
  * Worker health probes on port 5680 for v2+ runners

* **Documentation**
  * Updated README with n8n v2.0+ support and configuration guidance for v1.x and v2.x
  * Added example configurations for custom task runner setup

* **Chores**
  * Helm chart version bumped to 2.1.0; appVersion updated to 2.6.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->