### PR TITLE
bug(templates) : Fix bug on extraEnv.

### DIFF
--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
           env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}
             {{- range $key, $value := .Values.main.extraEnv }}
             - name: {{ $key }}
-              {{- toYaml $value | nindent 14 }}
+              value: {{ $value | quote }}
             {{- end }}
           lifecycle:
             {{- toYaml .Values.main.lifecycle | nindent 12 }}


### PR DESCRIPTION
Which issue this PR fixes
-------------------------

We didn't open an issue before

During our test, we tried to install an n8n instance with Helm charts.

In the deployment, we had an extraEnv variable in the values YAML.
[![image](https://private-user-images.githubusercontent.com/49709897/549539211-0c6ec275-7cd2-4caa-a274-a26ea2591d09.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5OTk3NjEsIm5iZiI6MTc3MDk5OTQ2MSwicGF0aCI6Ii80OTcwOTg5Ny81NDk1MzkyMTEtMGM2ZWMyNzUtN2NkMi00Y2FhLWEyNzQtYTI2ZWEyNTkxZDA5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjEzVDE2MTc0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWQyMGZjMWU4Yjg4N2Q0NzRiZWNlZmVkMWRiNmQ2NmJlZmFkMDEwOWYxNjgxYzVkZjU4YmJkYWExMTgxYjJhYzImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.tCsxmL_tCTEWujF9NWt-DlYuBHm-oJVFmO9IxTN47Oc)](https://private-user-images.githubusercontent.com/49709897/549539211-0c6ec275-7cd2-4caa-a274-a26ea2591d09.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5OTk3NjEsIm5iZiI6MTc3MDk5OTQ2MSwicGF0aCI6Ii80OTcwOTg5Ny81NDk1MzkyMTEtMGM2ZWMyNzUtN2NkMi00Y2FhLWEyNzQtYTI2ZWEyNTkxZDA5LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjEzVDE2MTc0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWQyMGZjMWU4Yjg4N2Q0NzRiZWNlZmVkMWRiNmQ2NmJlZmFkMDEwOWYxNjgxYzVkZjU4YmJkYWExMTgxYjJhYzImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.tCsxmL_tCTEWujF9NWt-DlYuBHm-oJVFmO9IxTN47Oc)

When we launched the helm manifest, we encounterd an error.

Error: INSTALLATION FAILED: YAML parse error on n8n/templates/deployment.yaml: error converting YAML to JSON: yaml: line 46: could not find expected ':'

After looking why, we observed that the helm chart does not write `value:` before the values key in the resulting manifests.

Example after launching this command in this project with the value file.

[![image](https://private-user-images.githubusercontent.com/49709897/549540273-c4e01da6-a6ae-4a45-828e-e36f96999fa4.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5OTk3NjEsIm5iZiI6MTc3MDk5OTQ2MSwicGF0aCI6Ii80OTcwOTg5Ny81NDk1NDAyNzMtYzRlMDFkYTYtYTZhZS00YTQ1LTgyOGUtZTM2Zjk2OTk5ZmE0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjEzVDE2MTc0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTc4OTE0M2U5YThhYjlkYjBiM2Q5MjJjMTk5MTA2YzE3MDdkODQ3YTMzMTc0ZDcyNzNmZTM1ZTY4NjkwMTQyNjQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.nBgwc24_m1N7IgZYiXzWOjqITFH-7I5tK_WLgO94v6w)](https://private-user-images.githubusercontent.com/49709897/549540273-c4e01da6-a6ae-4a45-828e-e36f96999fa4.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5OTk3NjEsIm5iZiI6MTc3MDk5OTQ2MSwicGF0aCI6Ii80OTcwOTg5Ny81NDk1NDAyNzMtYzRlMDFkYTYtYTZhZS00YTQ1LTgyOGUtZTM2Zjk2OTk5ZmE0LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjEzVDE2MTc0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTc4OTE0M2U5YThhYjlkYjBiM2Q5MjJjMTk5MTA2YzE3MDdkODQ3YTMzMTc0ZDcyNzNmZTM1ZTY4NjkwMTQyNjQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.nBgwc24_m1N7IgZYiXzWOjqITFH-7I5tK_WLgO94v6w) [![image](https://private-user-images.githubusercontent.com/49709897/549540512-bd359fd7-4858-43fc-b314-8b80c6602bb0.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5OTk3NjEsIm5iZiI6MTc3MDk5OTQ2MSwicGF0aCI6Ii80OTcwOTg5Ny81NDk1NDA1MTItYmQzNTlmZDctNDg1OC00M2ZjLWIzMTQtOGI4MGM2NjAyYmIwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjEzVDE2MTc0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWVmM2U4MmUxMjhjZTI5N2NiMzBiOTIyMGZjNmY0NmNkNmRmNWVhYjcxZDRhZmY1MTYxYmYyNjY2MDZmMDkxZGImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.XdwK8V0v6CXA79OfBE9LgHkQhTIXiJyqJqe_bG97H8A)](https://private-user-images.githubusercontent.com/49709897/549540512-bd359fd7-4858-43fc-b314-8b80c6602bb0.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5OTk3NjEsIm5iZiI6MTc3MDk5OTQ2MSwicGF0aCI6Ii80OTcwOTg5Ny81NDk1NDA1MTItYmQzNTlmZDctNDg1OC00M2ZjLWIzMTQtOGI4MGM2NjAyYmIwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjEzVDE2MTc0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWVmM2U4MmUxMjhjZTI5N2NiMzBiOTIyMGZjNmY0NmNkNmRmNWVhYjcxZDRhZmY1MTYxYmYyNjY2MDZmMDkxZGImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.XdwK8V0v6CXA79OfBE9LgHkQhTIXiJyqJqe_bG97H8A)

After seeing that, I updated this line on the project.

[![image](https://private-user-images.githubusercontent.com/49709897/549541126-41e81d02-9332-4075-a21f-561a4f6e9eee.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5OTk3NjEsIm5iZiI6MTc3MDk5OTQ2MSwicGF0aCI6Ii80OTcwOTg5Ny81NDk1NDExMjYtNDFlODFkMDItOTMzMi00MDc1LWEyMWYtNTYxYTRmNmU5ZWVlLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjEzVDE2MTc0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWJkM2YyMThjZWI0MDU3YmViOTRhY2YyM2NhNjFlYTI0NmNlOTg4N2RlN2ZkYzBhZGEyZDM5MTUxMTllZTQ2MzUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.oxzI_ebKbE063S0b66hELOo2Y7xNwxsL6lrnHe2dxpg)](https://private-user-images.githubusercontent.com/49709897/549541126-41e81d02-9332-4075-a21f-561a4f6e9eee.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzA5OTk3NjEsIm5iZiI6MTc3MDk5OTQ2MSwicGF0aCI6Ii80OTcwOTg5Ny81NDk1NDExMjYtNDFlODFkMDItOTMzMi00MDc1LWEyMWYtNTYxYTRmNmU5ZWVlLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjEzVDE2MTc0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWJkM2YyMThjZWI0MDU3YmViOTRhY2YyM2NhNjFlYTI0NmNlOTg4N2RlN2ZkYzBhZGEyZDM5MTUxMTllZTQ2MzUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.oxzI_ebKbE063S0b66hELOo2Y7xNwxsL6lrnHe2dxpg)

I relaunched the same command and I don't encounter the error.
By using the files made by the Helm chart fixed by our modification ti deploy n8n, the deployment works flawlessly.

Version Helm charts : 2.0.1
<!-- ## Special notes for your reviewer -->

<!-- Any additional context, special considerations, or things reviewers should pay attention to -->

## Checklist

Please place an 'x' in all applicable fields and remove unrelated items.

### Version and Documentation
- [ ] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [ ] App version updated in `Chart.yaml` if applicable
- [ ] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [ ] Variables are documented in the `README.md`
### Testing and Validation
- [ ] Ran `ah lint` locally without errors
- [ ] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [ ] Tested chart installation locally
- [ ] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Environment variable configuration format updated in the Kubernetes deployment. Complex YAML structures for extraEnv are no longer supported; only simple scalar values are now accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->