### PR TITLE
feat: Add startupProbe support for all deployment types

### DIFF
--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -76,6 +76,10 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.webhook.config.n8n) "port" | default 5678 }}
               protocol: TCP
+          {{- with .Values.webhook.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.webhook.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -99,6 +99,10 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.worker.config.n8n) "port" | default 5678 }}
               protocol: TCP
+          {{- with .Values.worker.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.worker.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.main.config.n8n) "port" | default 5678 }}
               protocol: TCP
+          {{- with .Values.main.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.main.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -199,6 +199,20 @@ main:
   #  - -c
   #  - chmod o+rx /root; chown -R node /root/.n8n || true; chown -R node /root/.n8n; ln -s /root/.n8n /home/node; chown -R node /home/node || true; node /usr/local/bin/n8n
 
+  # here you can override the startupProbe for the main container
+  # startupProbe runs during container startup and disables liveness/readiness checks until it succeeds.
+  # This is useful for slow-starting containers that need time to initialize before health checks begin.
+  # See https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-startup-probes
+  startupProbe: {}
+  # httpGet:
+  #   path: /healthz
+  #   port: http
+  # initialDelaySeconds: 10
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 30
+  # successThreshold: 1
+
   # here you can override the livenessProbe for the main container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
 
@@ -396,7 +410,19 @@ worker:
   # command args
   commandArgs: []
 
-  # here you can override the livenessProbe for the main container
+  # here you can override the startupProbe for the worker container
+  # startupProbe runs during container startup and disables liveness/readiness checks until it succeeds.
+  startupProbe: {}
+  # httpGet:
+  #   path: /healthz
+  #   port: http
+  # initialDelaySeconds: 10
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 30
+  # successThreshold: 1
+
+  # here you can override the livenessProbe for the worker container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
   livenessProbe:
     httpGet:
@@ -408,7 +434,7 @@ worker:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
+  # here you can override the readinessProbe for the worker container
   # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
 
   readinessProbe:
@@ -585,7 +611,19 @@ webhook:
   # Command Arguments
   commandArgs: []
 
-  # here you can override the livenessProbe for the main container
+  # here you can override the startupProbe for the webhook container
+  # startupProbe runs during container startup and disables liveness/readiness checks until it succeeds.
+  startupProbe: {}
+  # httpGet:
+  #   path: /healthz
+  #   port: http
+  # initialDelaySeconds: 10
+  # periodSeconds: 10
+  # timeoutSeconds: 5
+  # failureThreshold: 30
+  # successThreshold: 1
+
+  # here you can override the livenessProbe for the webhook container
   # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
 
   livenessProbe:
@@ -598,7 +636,7 @@ webhook:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
+  # here you can override the readinessProbe for the webhook container
   # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
 
   readinessProbe:


### PR DESCRIPTION
## Summary

- Adds optional `startupProbe` configuration support for main, worker, and webhook deployments
- Follows the same pattern as existing `livenessProbe` and `readinessProbe` configuration
- Defaults to empty (no startupProbe), fully backwards-compatible

## Motivation

Kubernetes `startupProbe` allows slow-starting containers to initialize before liveness/readiness checks begin. This is particularly important for n8n in queue mode where workers need time to connect to Redis and Postgres before becoming healthy.

Without a startupProbe, the only option is to increase `initialDelaySeconds` or `failureThreshold` on the liveness probe, which also makes the probe less responsive to actual failures after startup completes.

### Example usage

```yaml
main:
  startupProbe:
    httpGet:
      path: /healthz
      port: http
    initialDelaySeconds: 10
    periodSeconds: 10
    timeoutSeconds: 5
    failureThreshold: 30  # 30 * 10s = 5 min startup window

worker:
  startupProbe:
    httpGet:
      path: /healthz
      port: http
    failureThreshold: 30
    periodSeconds: 10
```

## Changes

- `templates/deployment.yaml` — added `startupProbe` block for main container
- `templates/deployment.worker.yaml` — added `startupProbe` block for worker container
- `templates/deployment.webhook.yaml` — added `startupProbe` block for webhook container
- `values.yaml` — added documented `startupProbe: {}` defaults for all three sections

## Test plan

- [x] `helm template` renders startupProbe correctly when values are provided
- [x] `helm template` renders without startupProbe when values are empty (backwards-compatible)
- [x] No breaking changes to existing configurations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added startup probe configuration support for all container types (main, worker, webhook) in Kubernetes deployments, enabling custom startup probe definitions with HTTP and timing options via Helm configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->