### PR TITLE
Update valkey repository URL to OCI format

### DIFF
--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: valkey
-  repository: https://valkey.io/valkey-helm/
+  repository: oci://ghcr.io/valkey-io/valkey-helm
   version: 0.8.1
-digest: sha256:9f554436d4d0d4b2817ab949eb90d2ddcc770fc5e60278bfed353d5fece6d5a6
-generated: "2025-12-01T23:58:16.062167+01:00"
+digest: sha256:3370d040839bfe0769def9b8fe925283069b718a172251d22d62c77419d79c60
+generated: "2026-02-19T18:34:26.033881192+01:00"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -27,7 +27,7 @@ maintainers:
 dependencies:
   - name: valkey
     version: 0.8.1
-    repository: https://valkey.io/valkey-helm/
+    repository: oci://ghcr.io/valkey-io/valkey-helm
     condition: valkey.enabled
 
 annotations:
@@ -35,4 +35,4 @@ annotations:
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
     - kind: changed
-      description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"
+      description: "Update valkey repository URL to OCI format"


### PR DESCRIPTION
## What this PR does / why we need it

Update to valkey repo to OCI format to be future proof. 

## Special notes for your reviewer

It makes it easier to pull the dep. chart over a proxy harbor. 

## Checklist


### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema)
- [ ] App version updated in `Chart.yaml` if applicable
- [x] `artifacthub.io/changes` section updated in `Chart.yaml` (see [ArtifactHub annotation reference](https://artifacthub.io/docs/topics/annotations/helm/))
- [ ] Variables are documented in the `README.md`
### Testing and Validation
- [ ] Ran `ah lint` locally without errors
- [ ] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [ ] Tested with example configurations in `/examples` directory



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Chart version bumped for a patch release.
  * External dependency source switched to an OCI registry to simplify distribution.
  * Release metadata updated to reflect the repository format change.
  * No runtime or behavioral changes introduced; existing functionality remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->