### PR TITLE
fix: clarify persistence.type requirement and document DB_SQLITE_POOL_SIZE for SQLite crash recovery

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,5 +34,7 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"
+    - kind: fixed
+      description: "Clarify that persistence.type must be set to 'dynamic' when enabling PVC storage; enabled: true alone has no effect without it"
+    - kind: fixed
+      description: "Document DB_SQLITE_POOL_SIZE requirement for SQLite crash recovery with persistent storage; without a read connection pool n8n enters a permanent CrashLoopBackOff after any pod crash"

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -83,12 +83,25 @@ main:
   #          name: db-app
   #          key: dbname
   #
+  # When using SQLite with persistence (persistence.type: dynamic or existing),
+  # set DB_SQLITE_POOL_SIZE to a value greater than zero. Without a read
+  # connection pool, n8n cannot recover the SQLite database after a crash and
+  # enters a permanent CrashLoopBackOff. This is not required when using PostgreSQL.
+  #    DB_SQLITE_POOL_SIZE:
+  #      value: "4"
+  #
   # N8n Kubernetes specific settings
   #
   persistence:
-    # If true, use a Persistent Volume Claim, If false, use emptyDir
+    # If true, use a Persistent Volume Claim, If false, use emptyDir.
+    # IMPORTANT: enabling persistence alone is not enough — you must also set
+    # type: dynamic (or type: existing with existingClaim) for the PVC to be
+    # mounted. Leaving type: emptyDir while enabled: true has no effect.
     enabled: false
-    # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
+    # Volume type. Options: emptyDir | dynamic | existing
+    #   dynamic  - provisions a new PVC via the storageClass
+    #   existing - uses an existing PVC specified in existingClaim
+    #   emptyDir - ephemeral storage (data lost on pod restart)
     type: emptyDir
     # Persistent Volume Storage Class
     # If defined, storageClassName: <storageClass>


### PR DESCRIPTION
## Problem

Two related issues that cause n8n to enter a permanent `CrashLoopBackOff` when using persistent storage with SQLite:

### 1. `persistence.type` is not obvious

Setting `persistence.enabled: true` without also setting `persistence.type: dynamic` has **no effect** — the chart silently uses `emptyDir`. The previous comment listed the three options in a single line but did not make clear that `enabled: true` alone is insufficient.

### 2. SQLite crash recovery fails with `DB_SQLITE_POOL_SIZE=0`

In n8n 1.x, when a pod is killed (e.g. by a liveness probe timeout or OOM) while SQLite is open, the database is left in an inconsistent state. On the next restart n8n logs:

\`\`\`
Last session crashed
Database connection timed out
\`\`\`

…and the pod immediately crashes again, creating an unrecoverable loop. This only manifests with **persistent storage** (PVC): with `emptyDir` each new pod starts with a clean database, so the loop never forms. Setting `DB_SQLITE_POOL_SIZE` to a non-zero value allows n8n to recover the SQLite connection after a crash.

n8n already emits a deprecation warning for this:
> `DB_SQLITE_POOL_SIZE` → Running SQLite without a pool of read connections is deprecated.

## Changes

- Rewrite the `persistence.type` comment to name all three options clearly and add an **IMPORTANT** note that `enabled: true` alone is not enough.
- Add a commented `DB_SQLITE_POOL_SIZE` example under `extraEnv` with an explanation of why it is required for SQLite crash recovery when persistence is enabled.

## Testing

Reproduced the crash loop on a live cluster (n8n 1.122.4, chart 2.0.1):
1. Deploy with `persistence.enabled: true` + `type: dynamic` but without `DB_SQLITE_POOL_SIZE`
2. Pod crashes once (liveness probe timeout during first boot)
3. Pod enters permanent `CrashLoopBackOff` — only recovers after deleting the PVC

After setting `DB_SQLITE_POOL_SIZE: "4"` the pod recovers cleanly from crashes.

`helm lint` passes with no errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved SQLite crash recovery issue that could trigger persistent restart loops when using dynamic or existing persistence storage types.

* **Documentation**
  * Improved Helm chart configuration documentation with enhanced guidance for SQLite deployments, including database pool size settings and persistence type requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->