### PR TITLE
Fix worker/webhook PVC sharing, add HA queue mode config for SYSTEMS-804

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+## Bitovi fork
+
+This is Bitovi's fork of [8gears/n8n-helm-chart](https://github.com/8gears/n8n-helm-chart), used to deploy HA n8n on the [Bitovi Platform](https://github.com/bitovi/bitovi-platform-services) (SYSTEMS-804). Deviations from upstream:
+
+- **`worker`/`webhook` pods no longer mount `main`'s PVC.** Upstream's `deployment.worker.yaml` and `deployment.webhook.yaml` both reused the same `n8n.pvc` helper as `main`, which resolves to the same PVC name for every Deployment — on a multi-node cluster this causes `Multi-Attach error for volume` when worker/webhook pods land on a different node than main (upstream [#280](https://github.com/8gears/n8n-helm-chart/issues/280), [#189](https://github.com/8gears/n8n-helm-chart/issues/189); the `worker.persistence`/`webhook.persistence` values that look like they'd fix this are dead code — [#256](https://github.com/8gears/n8n-helm-chart/issues/256)). Fixed here by giving `worker`/`webhook` a plain `emptyDir` instead: they don't need to persist `/home/node/.n8n` since real state lives in Postgres and the queue, and the encryption key is sourced from a secret-backed env var, not a locally cached file. `main` keeps its real PVC via `main.persistence`, unchanged.
+- **HA scope**: this delivers HA workers + webhooks under queue mode. It does **not** implement multi-main HA ([#278](https://github.com/8gears/n8n-helm-chart/issues/278)) or an external task-runner pool ([#267](https://github.com/8gears/n8n-helm-chart/issues/267)) — both are open, unresolved upstream feature requests. `main` runs as a single replica; n8n's default in-process task runner is used as-is.
+- `charts/n8n/configurations/production/values.yaml` (alongside the base `values.yaml`) holds the Bitovi Platform deployment's actual settings: queue mode, bundled Valkey, community nodes and metrics on, an in-cluster CNPG Postgres `Cluster`, `OnePasswordItem`-backed secrets, and the Ingress/DNS for `n8n.bitovi-tools.com`.
+
+---
+
 [![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/n8n)](https://artifacthub.io/packages/helm/open-8gears/n8n)
 
 > [!NOTE]

--- a/charts/n8n/configurations/production/values.yaml
+++ b/charts/n8n/configurations/production/values.yaml
@@ -1,0 +1,201 @@
+# =============================================================================
+# Bitovi Platform - n8n production values (SYSTEMS-804)
+# =============================================================================
+# Layered on top of the base ../../values.yaml via the ArgoCD Application in
+# bitovi/bitovi-platform-services (gitops/apps/n8n.yaml). See that repo's
+# gitops/README.md for the app-of-apps convention this follows.
+#
+# fullnameOverride is pinned so every generated resource name (CNPG Cluster,
+# its "-app" Secret, the "-rw" Service, the main/worker/webhook Deployments)
+# is deterministic and can be cross-referenced below without a templating
+# indirection values.yaml files don't support. If you change this, update
+# the DB_POSTGRESDB_* values and cnpg.appSecretName together - they can't be
+# derived from each other automatically in a plain values file.
+#
+# The bundled Valkey subchart does NOT inherit fullnameOverride (it isn't a
+# global value), so main.config.queue.bull.redis.host below ("n8n-valkey")
+# is only correct if the Helm release name is literally "n8n" - set
+# `helm.releaseName: n8n` on the ArgoCD Application in gitops/apps/n8n.yaml.
+# =============================================================================
+
+fullnameOverride: "n8n"
+
+image:
+  repository: n8nio/n8n
+  tag: "1.122.4" # pinned to this chart's appVersion - bump deliberately, never "latest"
+  pullPolicy: IfNotPresent
+
+# ---------------------------------------------------------------------------
+# Ingress (AWS Load Balancer Controller)
+# ---------------------------------------------------------------------------
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: "443"
+    # TODO: fill in once an ACM Certificate is provisioned for this host
+    # (via the platform's ack-acm-controller) - the ALB won't serve HTTPS
+    # without it.
+    alb.ingress.kubernetes.io/certificate-arn: "REPLACE_WITH_ACM_CERTIFICATE_ARN"
+  hosts:
+    - host: n8n.bitovi-tools.com
+      paths:
+        - path: /
+          pathType: Prefix
+
+# ---------------------------------------------------------------------------
+# Main (single replica - see README's "HA scope" note: no multi-main support
+# upstream, this is the officially-supported topology)
+# ---------------------------------------------------------------------------
+main:
+  # Real persistence, unlike worker/webhook: community nodes with
+  # community_packages.enabled=true install to /home/node/.n8n/nodes, and
+  # this is the only pod that would otherwise lose them on every restart.
+  persistence:
+    enabled: true
+    type: dynamic
+    size: 5Gi
+  config:
+    executions:
+      mode: queue
+    n8n:
+      community_packages:
+        enabled: true
+      metrics: true
+    db:
+      type: postgresdb
+      postgresdb:
+        host: n8n-db-rw # CNPG Cluster "n8n-db" read-write Service
+        port: 5432
+        database: app # CNPG default bootstrap database/owner name
+        user: app
+    queue:
+      bull:
+        redis:
+          host: n8n-valkey # bundled Valkey subchart Service, named "<release>-valkey"
+  extraEnv:
+    N8N_ENCRYPTION_KEY:
+      valueFrom:
+        secretKeyRef:
+          name: n8n-app-secrets # from OnePasswordItem, see onepassword.items below
+          key: encryption-key
+    DB_POSTGRESDB_PASSWORD:
+      valueFrom:
+        secretKeyRef:
+          name: n8n-db-app # CNPG-generated Secret for Cluster "n8n-db"
+          key: password
+    N8N_BASIC_AUTH_ACTIVE:
+      value: "true"
+    N8N_BASIC_AUTH_USER:
+      valueFrom:
+        secretKeyRef:
+          name: n8n-app-secrets
+          key: basic-auth-user
+    N8N_BASIC_AUTH_PASSWORD:
+      valueFrom:
+        secretKeyRef:
+          name: n8n-app-secrets
+          key: basic-auth-password
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+# ---------------------------------------------------------------------------
+# Worker (HA - this is the actual fix: stateless, no shared PVC, so multiple
+# replicas/nodes no longer hit the Multi-Attach bug)
+# ---------------------------------------------------------------------------
+worker:
+  enabled: true
+  replicaCount: 2
+  extraEnv:
+    N8N_ENCRYPTION_KEY:
+      valueFrom:
+        secretKeyRef:
+          name: n8n-app-secrets
+          key: encryption-key
+    DB_POSTGRESDB_PASSWORD:
+      valueFrom:
+        secretKeyRef:
+          name: n8n-db-app
+          key: password
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+
+# ---------------------------------------------------------------------------
+# Webhook (HA - same statelessness fix as worker)
+# ---------------------------------------------------------------------------
+webhook:
+  enabled: true
+  replicaCount: 2
+  extraEnv:
+    N8N_ENCRYPTION_KEY:
+      valueFrom:
+        secretKeyRef:
+          name: n8n-app-secrets
+          key: encryption-key
+    DB_POSTGRESDB_PASSWORD:
+      valueFrom:
+        secretKeyRef:
+          name: n8n-db-app
+          key: password
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+# ---------------------------------------------------------------------------
+# Queue backend: the chart's bundled Valkey subchart. No shared platform
+# Redis exists (or is needed) for this app.
+# ---------------------------------------------------------------------------
+valkey:
+  enabled: true
+
+# ---------------------------------------------------------------------------
+# In-cluster Postgres via the already-installed CNPG operator - first use of
+# it on this platform. See templates/cnpg-cluster.yaml.
+# ---------------------------------------------------------------------------
+cnpg:
+  enabled: true
+  instances: 2
+  storage:
+    size: 10Gi
+  appSecretName: n8n-db-app # must match "<cnpg Cluster name>-app"; informational, see note above
+
+# ---------------------------------------------------------------------------
+# Secrets via the 1Password Kubernetes Operator (Connect mode), matching the
+# pattern already established by pto-api (bitovi/pto-api PR, and
+# bitovi-platform-services gitops/apps/onepassword-connect.yaml PR #11).
+# The 1Password item "n8n-app-secrets" needs fields: basic-auth-user,
+# basic-auth-password, encryption-key.
+# ---------------------------------------------------------------------------
+onepassword:
+  enabled: true
+  vault: bitovi-platform # TODO: confirm actual vault name/ID with whoever owns the 1Password Connect setup
+  items:
+    n8n-app-secrets: n8n-app-secrets
+
+# ---------------------------------------------------------------------------
+# DNS via the ACK Route53 controller, pointing at the shared bitovi-tools.com
+# zone (bitovi-platform-services gitops/infrastructure/route53-zones).
+# Two-step bootstrap required - see templates/route53-recordset.yaml.
+# ---------------------------------------------------------------------------
+route53:
+  enabled: true
+  hostedZoneRefName: bitovi-tools-com
+  recordName: n8n.bitovi-tools.com
+  target: "REPLACE_AFTER_FIRST_APPLY_WITH_ALB_HOSTNAME"

--- a/charts/n8n/templates/cnpg-cluster.yaml
+++ b/charts/n8n/templates/cnpg-cluster.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.cnpg.enabled }}
+# Requires the CloudNativePG operator already installed on the target
+# cluster. CNPG bootstraps a default "app" database + "app" user and
+# generates a Secret named "<cluster-name>-app" with keys: username,
+# password, dbname, host, port, uri, jdbc-uri. n8n's DB_POSTGRESDB_* env
+# vars are wired to that Secret from main/worker/webhook extraEnv in
+# values.yaml (see cnpg.appSecretName) - no OnePasswordItem needed for DB
+# creds, CNPG manages that lifecycle itself.
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: {{ include "n8n.fullname" . }}-db
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  instances: {{ .Values.cnpg.instances }}
+  storage:
+    size: {{ .Values.cnpg.storage.size }}
+    {{- if .Values.cnpg.storage.storageClass }}
+    storageClass: {{ .Values.cnpg.storage.storageClass }}
+    {{- end }}
+{{- end }}

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -140,7 +140,13 @@ spec:
       {{- end }}
       volumes:
         - name: "data"
-          {{ include "n8n.pvc" . }}
+          # Intentionally stateless: webhook pods don't persist /home/node/.n8n.
+          # Real state lives in Postgres (workflows/executions) and the queue
+          # (Redis/Valkey); the encryption key comes from an env var, not a
+          # locally cached file. Sharing main's PVC here caused Multi-Attach
+          # errors when worker/webhook land on a different node than main
+          # (upstream: 8gears/n8n-helm-chart#280, #189, #256).
+          emptyDir: {}
         {{- if .Values.webhook.extraVolumes }}
           {{- toYaml .Values.webhook.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -136,7 +136,13 @@ spec:
       {{- end }}
       volumes:
         - name: "data"
-          {{ include "n8n.pvc" . }}
+          # Intentionally stateless: worker pods don't persist /home/node/.n8n.
+          # Real state lives in Postgres (workflows/executions) and the queue
+          # (Redis/Valkey); the encryption key comes from an env var, not a
+          # locally cached file. Sharing main's PVC here caused Multi-Attach
+          # errors when worker/webhook land on a different node than main
+          # (upstream: 8gears/n8n-helm-chart#280, #189, #256).
+          emptyDir: {}
         {{- if .Values.worker.extraVolumes }}
           {{- toYaml .Values.worker.extraVolumes | nindent 8 }}
         {{- end }}

--- a/charts/n8n/templates/onepassword-items.yaml
+++ b/charts/n8n/templates/onepassword-items.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.onepassword.enabled }}
+{{- /*
+Requires the 1Password Kubernetes Operator (Connect mode) already installed
+and watching this namespace - see bitovi/bitovi-platform-services
+gitops/apps/onepassword-connect.yaml. Each entry in .Values.onepassword.items
+is "<k8s-secret-name>: <1password-item-name>"; the operator syncs the
+1Password item's fields into a same-named Kubernetes Secret whose keys match
+the item's field labels. Reference the resulting Secrets via
+extraEnv.*.valueFrom.secretKeyRef in values.yaml, same as CNPG's Secret.
+*/}}
+{{- range $secretName, $itemName := .Values.onepassword.items }}
+---
+apiVersion: onepassword.com/v1
+kind: OnePasswordItem
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "n8n.labels" $ | nindent 4 }}
+spec:
+  itemPath: "vaults/{{ $.Values.onepassword.vault }}/items/{{ $itemName }}"
+{{- end }}
+{{- end }}

--- a/charts/n8n/templates/route53-recordset.yaml
+++ b/charts/n8n/templates/route53-recordset.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.route53.enabled }}
+{{- /*
+Requires the ACK Route53 controller already installed (see
+bitovi/bitovi-platform-services gitops/apps/ack-route53-controller.yaml),
+watching a shared, platform-owned HostedZone (gitops/infrastructure/route53-zones).
+A CNAME (not an alias record) is used since this is a subdomain, not the zone
+apex - simpler than an ALB alias target, which additionally requires the
+ALB's region-specific hosted zone ID.
+
+Bootstrap note: the ALB's DNS hostname doesn't exist until the AWS Load
+Balancer Controller provisions it from this chart's Ingress, so this is a
+two-step apply: 1) install with route53.enabled=false (or route53.target
+unset) so the Ingress creates the ALB, 2) `kubectl get ingress -n <ns>
+<release>-n8n` for the ALB hostname, set route53.target to it, re-apply.
+*/}}
+apiVersion: route53.services.k8s.aws/v1alpha1
+kind: RecordSet
+metadata:
+  name: {{ include "n8n.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "n8n.labels" . | nindent 4 }}
+spec:
+  name: {{ required "route53.recordName is required when route53.enabled=true" .Values.route53.recordName }}
+  type: CNAME
+  ttl: 300
+  hostedZoneRef:
+    from:
+      name: {{ required "route53.hostedZoneRefName is required when route53.enabled=true" .Values.route53.hostedZoneRefName }}
+  resourceRecords:
+    - value: {{ required "route53.target is required when route53.enabled=true (ALB hostname, set after first apply - see bootstrap note above)" .Values.route53.target }}
+{{- end }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -293,34 +293,14 @@ worker:
   #
   # Worker Kubernetes specific settings
   #
-  persistence:
-    # If true, use a Persistent Volume Claim, If false, use emptyDir
-    enabled: false
-    # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
-    type: emptyDir
-    # Persistent Volume Storage Class
-    # If defined, storageClassName: <storageClass>
-    # If set to "-", storageClassName: "", which disables dynamic provisioning
-    # If undefined (the default) or set to null, no storageClassName spec is
-    #   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    #   GKE, AWS & OpenStack)
-    #
-    # storageClass: "-"
-    # PVC annotations
-    #
-    # If you need this annotation include it under `values.yml` file and pvc.yml template will add it.
-    # This is not maintained at Helm v3 anymore.
-    # https://github.com/8gears/n8n-helm-chart/issues/8
-    #
-    # annotations:
-    #   helm.sh/resource-policy: keep
-    # Persistent Volume Access Mode
-    accessModes:
-      - ReadWriteOnce
-    # Persistent Volume size
-    size: 1Gi
-    # Use an existing PVC
-    # existingClaim:
+  # NOTE: worker pods are intentionally stateless (emptyDir for /home/node/.n8n,
+  # hardcoded in templates/deployment.worker.yaml) and do not read a
+  # `persistence` block here. An earlier version of this chart exposed
+  # worker.persistence/webhook.persistence keys that looked configurable but
+  # were never actually wired to anything (see 8gears/n8n-helm-chart#256) —
+  # they've been removed rather than left as dead config. Sharing main's PVC
+  # with worker/webhook caused Multi-Attach errors on multi-node clusters
+  # (8gears/n8n-helm-chart#280, #189); use main.persistence for real storage.
 
   # Number of desired pods.
   replicaCount: 1
@@ -479,37 +459,10 @@ webhook:
   #
   # Webhook Kubernetes specific settings
   #
-  persistence:
-    # If true, use a Persistent Volume Claim, If false, use emptyDir
-    enabled: false
-    # what type volume, possible options are [existing, emptyDir, dynamic] dynamic for Dynamic Volume Provisioning, existing for using an existing Claim
-    type: emptyDir
-    # Persistent Volume Storage Class
-    # If defined, storageClassName: <storageClass>
-    # If set to "-", storageClassName: "", which disables dynamic provisioning
-    # If undefined (the default) or set to null, no storageClassName spec is
-    #   set, choosing the default provisioner.  (gp2 on AWS, standard on
-    #   GKE, AWS & OpenStack)
-    #
-    # storageClass: "-"
-    # PVC annotations
-    #
-    # If you need this annotation include it under `values.yml` file and pvc.yml template will add it.
-    # This is not maintained at Helm v3 anymore.
-    # https://github.com/8gears/n8n-helm-chart/issues/8
-    #
-    # annotations:
-    #   helm.sh/resource-policy: keep
-    # Persistent Volume Access Mode
-    #
-    accessModes:
-      - ReadWriteOnce
-    # Persistent Volume size
-    #
-    size: 1Gi
-    # Use an existing PVC
-    #
-    # existingClaim:
+  # NOTE: webhook pods are intentionally stateless (emptyDir for
+  # /home/node/.n8n, hardcoded in templates/deployment.webhook.yaml) and do
+  # not read a `persistence` block here. See the matching note under `worker:`
+  # above for why (8gears/n8n-helm-chart#280, #189, #256).
 
   # Number of desired pods.
   replicaCount: 1
@@ -695,3 +648,43 @@ valkey:
   # dataStorage:
   #   enabled: false
   #   requestedSize: 2Gi
+
+# # # # # # # # # # # # # # # #
+#
+# Bitovi fork additions
+# See templates/cnpg-cluster.yaml, templates/onepassword-items.yaml,
+# templates/route53-recordset.yaml. All disabled by default so this chart
+# stays generically usable outside the Bitovi Platform.
+#
+
+# In-cluster Postgres via the CloudNativePG operator (assumed already
+# installed on the target cluster). Creates a postgresql.cnpg.io/v1 Cluster
+# and lets CNPG generate + manage the app-user credentials Secret itself.
+cnpg:
+  enabled: false
+  instances: 2
+  storage:
+    size: 10Gi
+  # storageClass: ""
+  # -- Name of the CNPG-managed app-user Secret (auto-created by CNPG as
+  # <name>-app). Referenced from main/worker/webhook extraEnv.
+  appSecretName: ""
+
+# 1Password Kubernetes Operator (Connect mode) OnePasswordItem resources.
+# Assumes the operator is already installed and watching this namespace.
+onepassword:
+  enabled: false
+  vault: ""
+  items: {}
+  # appSecrets: n8n-app-secrets   # -> basic-auth-user, basic-auth-password, encryption-key
+
+# ACK Route53 controller RecordSet, for platforms managing DNS via
+# aws-controllers-k8s rather than external-dns. References a shared,
+# platform-owned HostedZone by its Kubernetes name.
+route53:
+  enabled: false
+  hostedZoneRefName: ""
+  recordName: ""
+  # ALB hostname - only known after the Ingress creates the load balancer.
+  # See the bootstrap note in templates/route53-recordset.yaml.
+  target: ""


### PR DESCRIPTION
## Summary

Fixes a real, currently-open upstream bug and adds HA queue-mode configuration for deploying n8n on the Bitovi Platform ([SYSTEMS-804](https://bitovi.atlassian.net/browse/SYSTEMS-804)).

**The bug**: `worker` and `webhook` Deployments mount `/home/node/.n8n` via the same `n8n.pvc` helper as `main`, which resolves to the same PVC claim name regardless of which Deployment includes it. On a multi-node cluster, this causes `Multi-Attach error for volume` when worker/webhook pods land on a different node than main — a hard blocker for HA queue mode. Confirmed still open upstream: [#280](https://github.com/8gears/n8n-helm-chart/issues/280), [#189](https://github.com/8gears/n8n-helm-chart/issues/189); root cause confirmed in [#256](https://github.com/8gears/n8n-helm-chart/issues/256) — the `worker.persistence`/`webhook.persistence` values that look like they'd let you configure this separately are dead code, never wired to anything.

(Note: the *different* volume-mount bug the ticket originally flagged — mounting over `.n8n/` — was fixed upstream back in 2023, #55. This PR fixes the current, still-open one.)

**The fix**: `worker`/`webhook` now use a plain `emptyDir` instead of the shared PVC. They don't need to persist `/home/node/.n8n` — real state lives in Postgres (workflows/executions) and the queue (Valkey), and the encryption key comes from a secret-backed env var rather than a locally cached file. `main` is unchanged and keeps its real PVC via `main.persistence`.

## What else this adds

- `charts/n8n/configurations/production/values.yaml` — the production config for the Bitovi Platform: queue mode, bundled Valkey (no separate Redis needed), community nodes + metrics on by default (per the ticket), stock `n8nio/n8n` image (no custom image required for community nodes — they install dynamically).
- Three new opt-in chart templates (disabled by default, so the base chart stays generically usable outside this platform):
  - `templates/cnpg-cluster.yaml` — an in-cluster Postgres `Cluster` via the CloudNativePG operator (already installed on the platform, unused until now)
  - `templates/onepassword-items.yaml` — `OnePasswordItem` secrets (basic auth, encryption key), matching the pattern already established by `pto-api`
  - `templates/route53-recordset.yaml` — DNS via the platform's ACK Route53 controller
- Removed the dead `worker.persistence`/`webhook.persistence` value blocks rather than leaving them as misleading no-ops.
- README documents the fix and explicitly scopes what this does *not* do: no multi-main HA ([#278](https://github.com/8gears/n8n-helm-chart/issues/278)) or external task-runner pool ([#267](https://github.com/8gears/n8n-helm-chart/issues/267)) — both open, unresolved upstream feature requests. This delivers HA workers + webhooks with a single main pod, which is what's actually achievable today.

## Test plan

- [x] `helm lint` passes
- [x] `helm template` with the production values renders cleanly; verified `main` gets a real PVC (`persistentVolumeClaim`) while `worker`/`webhook` get `emptyDir`, both with and without `main.persistence.enabled`
- [x] Verified all cross-referenced resource names line up (CNPG `Cluster` → `n8n-db`, its auto-generated Secret → `n8n-db-app`, Valkey Service → `n8n-valkey`) given `fullnameOverride: "n8n"` and Helm release name `n8n`
- [ ] Deploy via ArgoCD ([bitovi-platform-services#20](https://github.com/bitovi/bitovi-platform-services/pull/20)) and confirm no PVC Multi-Attach errors on worker/webhook, queue mode actually routes executions through a worker
- [ ] Kill a worker pod, confirm it reschedules with no volume-attach delay

## Known placeholders (documented inline, need real values before this fully deploys)

- ACM certificate ARN for the ALB Ingress
- ALB hostname for the Route53 `RecordSet` (only known after first apply — two-step bootstrap, see comment in `templates/route53-recordset.yaml`)
- 1Password vault name (currently `bitovi-platform`, needs confirming with whoever owns the Connect setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/8gears/n8n-helm-chart/pull/301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added production-ready deployment settings for n8n, including ingress, database, cache, secret, and DNS integration options.
  * Added support for optional in-cluster Postgres, secret provisioning, and Route53 record creation.

* **Bug Fixes**
  * Made worker and webhook pods stateless to avoid storage conflicts and Multi-Attach issues.
  * Removed unused persistence settings for worker and webhook components.

* **Documentation**
  * Updated repository notes to clarify this fork’s differences from upstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->