### PR TITLE
fix: default ingress pathType to Prefix and fix ClusterIP_ service type typo

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.0.1
+version: 2.0.2
 appVersion: 1.122.4
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -34,5 +34,7 @@ annotations:
   artifacthub.io/prerelease: "false"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Changed the ingress logic to allow different types of pathType in place of the hardcoded 'pathType: Prefix'"
+    - kind: fixed
+      description: "Ingress paths default to pathType 'Prefix' again when the value is omitted, instead of rendering an empty pathType"
+    - kind: fixed
+      description: "Fixed typo in the main service type fallback that rendered the invalid value 'ClusterIP_'"

--- a/charts/n8n/templates/ingress.yaml
+++ b/charts/n8n/templates/ingress.yaml
@@ -32,7 +32,7 @@ spec:
         paths:
           {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}
@@ -40,7 +40,7 @@ spec:
                   number: {{ $.Values.main.service.port | default 80  }}
           {{- if $.Values.webhook.enabled }}
           - path: {{ trimSuffix "/" .path }}/webhook/
-            pathType: {{ .pathType }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}-webhook
@@ -48,21 +48,21 @@ spec:
                   number: {{ $.Values.webhook.service.port | default 80  }}
           # Note: The default URL for manual workflow executions is /webhook-test/*. Make sure that these URLs route to your main process.
           - path: {{ trimSuffix "/" .path }}/webhook-test/
-            pathType: {{ .pathType }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}
                 port:
                   number: {{ $.Values.main.service.port  | default 80  }}
           - path: {{ trimSuffix "/" .path }}/webhook-waiting/
-            pathType: {{ .pathType }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}-webhook
                 port:
                   number: {{ $.Values.webhook.service.port | default 80  }}
           - path: {{ trimSuffix "/" .path }}/form/
-            pathType: {{ .pathType }}
+            pathType: {{ .pathType | default "Prefix" }}
             backend:
               service:
                 name: {{ $fullName }}-webhook

--- a/charts/n8n/templates/service.yaml
+++ b/charts/n8n/templates/service.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ default "ClusterIP_" .Values.main.service.type }}
+  type: {{ .Values.main.service.type | default "ClusterIP" }}
   ports:
     - port: {{ default 80 .Values.main.service.port }}
       targetPort: http


### PR DESCRIPTION
## What this PR does / why we need it

Fixes two template bugs that make the chart render invalid Kubernetes manifests.

**Ingress `pathType` renders empty (#303)** — a regression from #271, which replaced the hardcoded `pathType: Prefix` with `pathType: {{ .pathType }}` in all five path entries. Helm replaces list values wholesale rather than merging them, so any consumer supplying `ingress.hosts` without a `pathType` key gets `pathType:` (null) and the API server rejects the Ingress. Defaulting to `Prefix` restores the pre-#271 behaviour while keeping the per-path override introduced by #271.

**`ClusterIP_` typo in `service.yaml` (#304)** — the fallback for `main.service.type` was misspelled, so setting the value to empty renders the invalid Service type `ClusterIP_`. The expression is now also written in the same order as the one already used in `service.webhook.yaml`.

## Which issue this PR fixes

fixes #303, fixes #304

## Special notes for your reviewer

Both bugs only surface for consumers who deviate from the shipped `values.yaml` (which sets `pathType: Prefix` and `type: ClusterIP`), which is why the default render never caught them.

Reproduction before the fix, with `values.yaml` containing `ingress.hosts[0].paths[0]` without `pathType` and `main.service.type: ""`:

```yaml
  type: ClusterIP_
...
            pathType:
```

After the fix, the same values render `type: ClusterIP` and `pathType: Prefix`. With an explicit `pathType: ImplementationSpecific` and `webhook.enabled=true`, the value propagates to all five derived paths as before.

## Checklist

### Version and Documentation
- [x] Chart version updated in `Chart.yaml` following [semantic versioning](CONTRIBUTING.md#chart-versioning-schema) (2.0.1 → 2.0.2)
- [ ] App version updated in `Chart.yaml` if applicable — not applicable, no app change
- [x] `artifacthub.io/changes` section updated in `Chart.yaml`
- [ ] Variables are documented in the `README.md` — not applicable, no new or changed variables

### Testing and Validation
- [x] Ran `ah lint` locally without errors
- [x] Ran Chart-Testing: `ct lint --chart-dirs charts/n8n --charts charts/n8n --validate-maintainers=false`
- [x] Tested chart installation locally
- [x] Tested with example configurations in `/examples` directory (all three render successfully)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/8gears/n8n-helm-chart/pull/305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ingress routes now correctly default to the `Prefix` path type when no path type is specified.
  * Corrected the default service type to `ClusterIP`, improving chart deployment behavior when no custom type is configured.
* **Chores**
  * Updated the Helm chart release version and documented the fixes in release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->