### PR TITLE
fix: bug: chart doesn't read worker.lifecycle

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -45,7 +45,5 @@ annotations:
       url: https://docs.n8n.io/hosting/configuration/environment-variables/
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update n8n to 2.35.7. This moves installations that do not pin image.tag from the n8n 1.x line to 2.x"
-    - kind: added
-      description: "Added Artifact Hub category, license and named links metadata"
+    - kind: fixed
+      description: "Apply worker.lifecycle to the worker deployment container, it was previously ignored"

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -95,6 +95,10 @@ spec:
             - "worker"
             - "--concurrency={{ .Values.worker.concurrency }}"
           {{- end }}
+          {{- with .Values.worker.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: {{ get (default (dict) .Values.worker.config.n8n) "port" | default 5678 }}


### PR DESCRIPTION
Fixes #260

## Root cause

worker deployment template never renders worker.lifecycle

## Changes

- Render the container lifecycle block in deployment.worker.yaml from .Values.worker.lifecycle, guarded with `with` so rendered output is unchanged when the value is empty, and replaced the artifacthub.io/changes entry per CONTRIBUTING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring lifecycle handlers on worker containers through the deployment settings.

* **Bug Fixes**
  * Worker lifecycle configuration is now correctly applied to the worker deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->