### PR TITLE
fix: bug: Its only creating hpa for main node.

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -45,7 +45,5 @@ annotations:
       url: https://docs.n8n.io/hosting/configuration/environment-variables/
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update n8n to 2.35.7. This moves installations that do not pin image.tag from the n8n 1.x line to 2.x"
-    - kind: added
-      description: "Added Artifact Hub category, license and named links metadata"
+    - kind: fixed
+      description: "Render a HorizontalPodAutoscaler for worker and webhook deployments when their autoscaling.enabled is true, instead of only for main"


### PR DESCRIPTION
Fixes #276

## Root cause

HPA template only rendered for the main deployment

## Changes

- Added charts/n8n/templates/hpa.worker.yaml and hpa.webhook.yaml, rendering an autoscaling/v2 HorizontalPodAutoscaler targeting the '-worker' and '-webhook' deployments when the component and its autoscaling are enabled, mirroring the existing main HPA (CPU/memory targets optional). Updated the artifacthub.io/changes annotation as required by CONTRIBUTING.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of HorizontalPodAutoscalers for worker and webhook deployments when autoscaling is enabled.
  * Improved deployment configuration visibility and consistency for autoscaled workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->