### PR TITLE
fix: point readiness probes at /healthz/readiness and add startup probes

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -50,7 +50,9 @@ jobs:
 
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
-        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+        # Version increments are owned by release-please, which bumps Chart.yaml and the
+        # manifest together on merge. ct would otherwise demand a bump in every chart PR.
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --check-version-increment=false
 
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'

--- a/README.md
+++ b/README.md
@@ -301,9 +301,24 @@ related to the application deployment and operation but not the application itse
   #  - -c
   #  - chmod o+rx /root; chown -R node /root/.n8n || true; chown -R node /root/.n8n; ln -s /root/.n8n /home/node; chown -R node /home/node || true; node /usr/local/bin/n8n
 
-  # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # Startup probe for the main container.
+  # n8n only starts listening once the database connection and migrations are done, which can
+  # take minutes on a first install. Without a startup probe the liveness probe below kills the
+  # container mid-boot; while it runs, liveness and readiness are held off.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 10
+    # Allow up to 5 minutes (30 x periodSeconds) to come up.
+    failureThreshold: 30
 
+  # Liveness probe for the main container.
+  # Stays on /healthz, which only reports that the n8n process is running. A database outage
+  # should drain pods from the Service via the readiness probe, not restart every pod at once.
+  # To also have Kubernetes restart a pod whose DB connection never recovers, point this at
+  # /healthz/readiness with a failureThreshold high enough to ride out a short blip.
+  # See https://github.com/8gears/n8n-helm-chart/issues/308
   livenessProbe:
     httpGet:
       path: /healthz
@@ -314,12 +329,13 @@ related to the application deployment and operation but not the application itse
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
-
+  # Readiness probe for the main container.
+  # /healthz/readiness reflects the database connection and migration state, so a pod answering
+  # "Database is not ready!" is removed from the Service endpoints. /healthz returns 200 in that
+  # situation and would keep traffic flowing to a pod that cannot serve a single request.
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /healthz/readiness
       port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
@@ -380,7 +396,13 @@ worker:
   enabled: false
 
   # additional (to main) config for worker
-  config: {}
+  config:
+    queue:
+      health:
+        check:
+          # QUEUE_HEALTH_CHECK_ACTIVE. A worker starts no HTTP server unless this is true,
+          # so the liveness/readiness probes below have nothing to talk to without it.
+          active: true
 
   # additional (to main) config for worker
   secret: {}
@@ -497,8 +519,26 @@ worker:
   # command args
   commandArgs: []
 
-  # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # Startup probe for the worker container.
+  # Both worker endpoints only exist when QUEUE_HEALTH_CHECK_ACTIVE is true (worker.config.queue.health.check.active above);
+  # without it the worker serves no HTTP at all and these probes fail.
+  # n8n only starts listening once the database connection and migrations are done, which can
+  # take minutes on a first install. Without a startup probe the liveness probe below kills the
+  # container mid-boot; while it runs, liveness and readiness are held off.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 10
+    # Allow up to 5 minutes (30 x periodSeconds) to come up.
+    failureThreshold: 30
+
+  # Liveness probe for the worker container.
+  # Stays on /healthz, which only reports that the n8n process is running. A database outage
+  # should drain pods from the Service via the readiness probe, not restart every pod at once.
+  # To also have Kubernetes restart a pod whose DB connection never recovers, point this at
+  # /healthz/readiness with a failureThreshold high enough to ride out a short blip.
+  # See https://github.com/8gears/n8n-helm-chart/issues/308
   livenessProbe:
     httpGet:
       path: /healthz
@@ -509,12 +549,12 @@ worker:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
-
+  # Readiness probe for the worker container.
+  # /healthz/readiness reflects the database and Redis connection state, so a worker that lost
+  # either is removed from the Service endpoints. /healthz returns 200 in that situation.
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /healthz/readiness
       port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
@@ -686,9 +726,24 @@ webhook:
   # Command Arguments
   commandArgs: []
 
-  # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # Startup probe for the webhook container.
+  # n8n only starts listening once the database connection and migrations are done, which can
+  # take minutes on a first install. Without a startup probe the liveness probe below kills the
+  # container mid-boot; while it runs, liveness and readiness are held off.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 10
+    # Allow up to 5 minutes (30 x periodSeconds) to come up.
+    failureThreshold: 30
 
+  # Liveness probe for the webhook container.
+  # Stays on /healthz, which only reports that the n8n process is running. A database outage
+  # should drain pods from the Service via the readiness probe, not restart every pod at once.
+  # To also have Kubernetes restart a pod whose DB connection never recovers, point this at
+  # /healthz/readiness with a failureThreshold high enough to ride out a short blip.
+  # See https://github.com/8gears/n8n-helm-chart/issues/308
   livenessProbe:
     httpGet:
       path: /healthz
@@ -699,12 +754,13 @@ webhook:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
-
+  # Readiness probe for the webhook container.
+  # /healthz/readiness reflects the database connection and migration state, so a pod answering
+  # "Database is not ready!" is removed from the Service endpoints. /healthz returns 200 in that
+  # situation and would keep traffic flowing to a pod that cannot serve a single request.
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /healthz/readiness
       port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10

--- a/README.md
+++ b/README.md
@@ -403,6 +403,9 @@ worker:
           # QUEUE_HEALTH_CHECK_ACTIVE. A worker starts no HTTP server unless this is true,
           # so the liveness/readiness probes below have nothing to talk to without it.
           active: true
+          # QUEUE_HEALTH_CHECK_PORT. Uncomment to move the worker health server; the container
+          # port and the probes follow it. N8N_PORT does not apply to workers.
+          # port: 5678
 
   # additional (to main) config for worker
   secret: {}

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.1.1
+version: 2.1.0
 appVersion: 2.35.7
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: n8n
-version: 2.1.0
+version: 2.1.1
 appVersion: 2.35.7
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
@@ -45,7 +45,9 @@ annotations:
       url: https://docs.n8n.io/hosting/configuration/environment-variables/
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: changed
-      description: "Update n8n to 2.35.7. This moves installations that do not pin image.tag from the n8n 1.x line to 2.x"
+    - kind: fixed
+      description: "Readiness probes now use /healthz/readiness, so a pod that lost its database connection is removed from the Service instead of staying Ready on /healthz"
     - kind: added
-      description: "Added Artifact Hub category, license and named links metadata"
+      description: "Added a startupProbe to the main, worker and webhook pods, so the liveness probe no longer kills containers that are still running migrations"
+    - kind: fixed
+      description: "Worker pods now default QUEUE_HEALTH_CHECK_ACTIVE to true and expose the queue health check port, without which the worker probes could never pass"

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -76,6 +76,10 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.webhook.config.n8n) "port" | default 5678 }}
               protocol: TCP
+          {{- with .Values.webhook.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.webhook.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -95,10 +95,17 @@ spec:
             - "worker"
             - "--concurrency={{ .Values.worker.concurrency }}"
           {{- end }}
+          {{- $workerConfig := default (dict) .Values.worker.config }}
           ports:
+            # The worker health server binds QUEUE_HEALTH_CHECK_PORT, not N8N_PORT, so prefer it;
+            # n8n.port stays as a fallback so existing overrides keep working.
             - name: http
-              containerPort: {{ get (default (dict) .Values.worker.config.n8n) "port" | default 5678 }}
+              containerPort: {{ dig "queue" "health" "port" (dig "n8n" "port" 5678 $workerConfig) $workerConfig }}
               protocol: TCP
+          {{- with .Values.worker.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.worker.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -95,12 +95,11 @@ spec:
             - "worker"
             - "--concurrency={{ .Values.worker.concurrency }}"
           {{- end }}
-          {{- $workerConfig := default (dict) .Values.worker.config }}
           ports:
-            # The worker health server binds QUEUE_HEALTH_CHECK_PORT, not N8N_PORT, so prefer it;
-            # n8n.port stays as a fallback so existing overrides keep working.
+            # A worker serves only the health endpoints, and binds QUEUE_HEALTH_CHECK_PORT to do
+            # so. N8N_PORT is never bound here, so it must not be used to derive this port.
             - name: http
-              containerPort: {{ dig "queue" "health" "port" (dig "n8n" "port" 5678 $workerConfig) $workerConfig }}
+              containerPort: {{ dig "queue" "health" "check" "port" 5678 (default (dict) .Values.worker.config) }}
               protocol: TCP
           {{- with .Values.worker.startupProbe }}
           startupProbe:

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
             - name: http
               containerPort: {{ get (default (dict) .Values.main.config.n8n) "port" | default 5678 }}
               protocol: TCP
+          {{- with .Values.main.startupProbe }}
+          startupProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.main.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -302,6 +302,9 @@ worker:
           # QUEUE_HEALTH_CHECK_ACTIVE. A worker starts no HTTP server unless this is true,
           # so the liveness/readiness probes below have nothing to talk to without it.
           active: true
+          # QUEUE_HEALTH_CHECK_PORT. Uncomment to move the worker health server; the container
+          # port and the probes follow it. N8N_PORT does not apply to workers.
+          # port: 5678
 
   # additional (to main) config for worker
   secret: {}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -199,9 +199,24 @@ main:
   #  - -c
   #  - chmod o+rx /root; chown -R node /root/.n8n || true; chown -R node /root/.n8n; ln -s /root/.n8n /home/node; chown -R node /home/node || true; node /usr/local/bin/n8n
 
-  # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # Startup probe for the main container.
+  # n8n only starts listening once the database connection and migrations are done, which can
+  # take minutes on a first install. Without a startup probe the liveness probe below kills the
+  # container mid-boot; while it runs, liveness and readiness are held off.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 10
+    # Allow up to 5 minutes (30 x periodSeconds) to come up.
+    failureThreshold: 30
 
+  # Liveness probe for the main container.
+  # Stays on /healthz, which only reports that the n8n process is running. A database outage
+  # should drain pods from the Service via the readiness probe, not restart every pod at once.
+  # To also have Kubernetes restart a pod whose DB connection never recovers, point this at
+  # /healthz/readiness with a failureThreshold high enough to ride out a short blip.
+  # See https://github.com/8gears/n8n-helm-chart/issues/308
   livenessProbe:
     httpGet:
       path: /healthz
@@ -212,12 +227,13 @@ main:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
-
+  # Readiness probe for the main container.
+  # /healthz/readiness reflects the database connection and migration state, so a pod answering
+  # "Database is not ready!" is removed from the Service endpoints. /healthz returns 200 in that
+  # situation and would keep traffic flowing to a pod that cannot serve a single request.
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /healthz/readiness
       port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
@@ -279,7 +295,13 @@ worker:
   enabled: false
 
   # additional (to main) config for worker
-  config: {}
+  config:
+    queue:
+      health:
+        check:
+          # QUEUE_HEALTH_CHECK_ACTIVE. A worker starts no HTTP server unless this is true,
+          # so the liveness/readiness probes below have nothing to talk to without it.
+          active: true
 
   # additional (to main) config for worker
   secret: {}
@@ -396,8 +418,26 @@ worker:
   # command args
   commandArgs: []
 
-  # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # Startup probe for the worker container.
+  # Both worker endpoints only exist when QUEUE_HEALTH_CHECK_ACTIVE is true (worker.config.queue.health.check.active above);
+  # without it the worker serves no HTTP at all and these probes fail.
+  # n8n only starts listening once the database connection and migrations are done, which can
+  # take minutes on a first install. Without a startup probe the liveness probe below kills the
+  # container mid-boot; while it runs, liveness and readiness are held off.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 10
+    # Allow up to 5 minutes (30 x periodSeconds) to come up.
+    failureThreshold: 30
+
+  # Liveness probe for the worker container.
+  # Stays on /healthz, which only reports that the n8n process is running. A database outage
+  # should drain pods from the Service via the readiness probe, not restart every pod at once.
+  # To also have Kubernetes restart a pod whose DB connection never recovers, point this at
+  # /healthz/readiness with a failureThreshold high enough to ride out a short blip.
+  # See https://github.com/8gears/n8n-helm-chart/issues/308
   livenessProbe:
     httpGet:
       path: /healthz
@@ -408,12 +448,12 @@ worker:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
-
+  # Readiness probe for the worker container.
+  # /healthz/readiness reflects the database and Redis connection state, so a worker that lost
+  # either is removed from the Service endpoints. /healthz returns 200 in that situation.
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /healthz/readiness
       port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10
@@ -585,9 +625,24 @@ webhook:
   # Command Arguments
   commandArgs: []
 
-  # here you can override the livenessProbe for the main container
-  # it may be used to increase the timeout for the livenessProbe (e.g., to resolve issues like
+  # Startup probe for the webhook container.
+  # n8n only starts listening once the database connection and migrations are done, which can
+  # take minutes on a first install. Without a startup probe the liveness probe below kills the
+  # container mid-boot; while it runs, liveness and readiness are held off.
+  startupProbe:
+    httpGet:
+      path: /healthz
+      port: http
+    periodSeconds: 10
+    # Allow up to 5 minutes (30 x periodSeconds) to come up.
+    failureThreshold: 30
 
+  # Liveness probe for the webhook container.
+  # Stays on /healthz, which only reports that the n8n process is running. A database outage
+  # should drain pods from the Service via the readiness probe, not restart every pod at once.
+  # To also have Kubernetes restart a pod whose DB connection never recovers, point this at
+  # /healthz/readiness with a failureThreshold high enough to ride out a short blip.
+  # See https://github.com/8gears/n8n-helm-chart/issues/308
   livenessProbe:
     httpGet:
       path: /healthz
@@ -598,12 +653,13 @@ webhook:
     # failureThreshold: 6
     # successThreshold: 1
 
-  # here you can override the readinessProbe for the main container
-  # it may be used to increase the timeout for the readinessProbe (e.g., to resolve issues like
-
+  # Readiness probe for the webhook container.
+  # /healthz/readiness reflects the database connection and migration state, so a pod answering
+  # "Database is not ready!" is removed from the Service endpoints. /healthz returns 200 in that
+  # situation and would keep traffic flowing to a pod that cannot serve a single request.
   readinessProbe:
     httpGet:
-      path: /healthz
+      path: /healthz/readiness
       port: http
     # initialDelaySeconds: 30
     # periodSeconds: 10


### PR DESCRIPTION
Fixes #308.

## Problem

`/healthz` returns `200 {"status":"ok"}` whenever the n8n process is up. It says nothing about the database. Because `livenessProbe` and `readinessProbe` both pointed at it, a pod that had lost its DB connection and was answering every request with `503 {"code":503,"message":"Database is not ready!"}` stayed `1/1 Ready`, kept its Service endpoint, and kept receiving ingress traffic until someone ran a manual `kubectl rollout restart`.

## Changes

**1. `readinessProbe` → `/healthz/readiness`** for `main`, `worker` and `webhook`. `livenessProbe` stays on `/healthz`.

**2. Added a `startupProbe`** (`/healthz`, `periodSeconds: 10`, `failureThreshold: 30`) to all three components, plus `startupProbe` support in the deployment templates.

**3. `worker.config.queue.health.check.active` now defaults to `true`** (`QUEUE_HEALTH_CHECK_ACTIVE`).

**4. Worker `containerPort` now derives from `queue.health.port`**, falling back to `n8n.port`, then `5678`.

## Why each change

Verified against the n8n 2.35.7 source and against running containers:

- `packages/cli/src/abstract-server.ts:151` — `/healthz` returns `{status:"ok"}` unconditionally. Line 157 — `/healthz/readiness` requires `connected && migrated && fullyReady`. Reproduced with Docker: with postgres stopped, `/healthz` → **200**, `/healthz/readiness` → **503**, `/rest/login` → **503 "Database is not ready!"**. Same result for the `webhook` process, which shares `AbstractServer`.
- `packages/cli/src/scaling/worker-server.ts:107-117` — the worker mounts health endpoints only when `queue.health.active` is true, and `packages/@n8n/config/src/configs/scaling-mode.config.ts:11` defaults that to **false**. Confirmed empirically: a worker without `QUEUE_HEALTH_CHECK_ACTIVE=true` has **nothing listening on 5678** (connection refused), so the worker probes this chart shipped could never pass. With it set, both endpoints work and readiness tracks DB *and* Redis (`worker-server.ts:145-148`).
- The worker health server binds `QUEUE_HEALTH_CHECK_PORT`, not `N8N_PORT`, so deriving `containerPort` from `n8n.port` pointed the probes at a port nothing listens on.
- **The startup probe was not optional.** Installing the old defaults on a kind cluster crash-looped all three pods (5 restarts each): `Container failed liveness probe, will be restarted`. n8n takes longer to start listening than the default 30s liveness grace (no `initialDelaySeconds` was set). Fixing readiness alone would have left that pre-existing bug in place.

## Verification

Real cluster (kind + postgres + valkey, `worker` and `webhook` enabled):

| | before | after |
|---|---|---|
| startup | 5+ liveness-driven restarts, never Ready | all 3 pods Ready, 0 liveness restarts |
| postgres scaled to 0 | pods stay `1/1 Ready`, keep serving traffic | pods go `0/1`, **`ready=False` on both EndpointSlices**, no restarts |
| postgres restored | needed manual `rollout restart` | all pods back to `1/1` on their own |

Default install (SQLite, no worker/webhook) also comes up `1/1` clean, with two readiness `503`s during boot and no restarts. `helm lint` and `ct lint` pass.

## One judgment call worth reviewing

`livenessProbe` deliberately stays on `/healthz`. Pointing it at `/healthz/readiness` would restart a pod whose connection pool never recovers, but during a DB maintenance window it restarts every pod in the fleet at once. The opt-in is documented in the values comments instead. Note that in testing the main pod *did* recover on its own once postgres returned, so a pool that never recovers looks Aurora-specific rather than general n8n behaviour.

`Chart.yaml` is untouched; release-please owns the version bump.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment stability during database initialization and migrations with startup probes.
  * Readiness checks now remove instances from service routing when database or Redis dependencies are unavailable.
  * Enabled worker health-check endpoints by default for improved monitoring.

* **Documentation**
  * Added guidance on startup, liveness, and readiness probes for main, worker, and webhook containers.
  * Documented the optional worker health-check port setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->