### PR TITLE
fix: update n8n to 2.36.8

### DIFF
--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: n8n
 version: 2.1.0
-appVersion: 2.35.7
+appVersion: 2.36.8
 type: application
 description: "Helm Chart for deploying n8n on Kubernetes, a fair-code workflow automation platform with native AI capabilities for technical teams. Easily automate tasks across different services."
 home: https://github.com/8gears/n8n-helm-chart
@@ -51,3 +51,5 @@ annotations:
       description: "Added a startupProbe to the main, worker and webhook pods, so the liveness probe no longer kills containers that are still running migrations"
     - kind: fixed
       description: "Worker pods now default QUEUE_HEALTH_CHECK_ACTIVE to true and expose the queue health check port, without which the worker probes could never pass"
+    - kind: changed
+      description: "Updated n8n to 2.36.8, the current stable release"


### PR DESCRIPTION
Updates `appVersion` to n8n 2.36.8, the current stable release, verified three ways: the GitHub release `n8n@2.36.8` is marked stable (the 2.37.x line is beta/prerelease), and Docker Hub's `stable`, `latest` and `2.36.8` tags all resolve to the same digest (`sha256:cfe270...`).

- `version` untouched per CONTRIBUTING.md; release-please bumps it. Once this merges, release PR #311 picks it up so chart 2.1.1 ships the probe fixes and the new app version together.
- `artifacthub.io/changes` gains an entry rather than being replaced: the probe-fix entries belong to the same unreleased chart version.
- Committed as `fix:` because app version updates are PATCH per the versioning schema, and the historical `chore:` type is hidden from release notes and cuts no release on its own.

Verified locally: `helm lint` passes and `helm template` with `examples/values_small.yaml` renders `image: "n8nio/n8n:2.36.8"` (tag falls back to `appVersion`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the n8n Helm chart to the latest stable release.
  * Added release change details to the chart metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->