### PR TITLE
feat: add optional n8n Sandbox Service support

### DIFF
--- a/README.md
+++ b/README.md
@@ -942,6 +942,20 @@ main:
           provider: n8n-sandbox
 ```
 
+The model credential is a separate variable, and which one depends on the provider prefix of
+`instance_ai.model`: a built-in provider reads its own SDK variable, so `anthropic/*` needs
+`ANTHROPIC_API_KEY`, `openai/*` needs `OPENAI_API_KEY`, `google/*` needs
+`GOOGLE_GENERATIVE_AI_API_KEY`, and mistral, groq, cohere, deepseek, openrouter and xai follow the
+same pattern. `N8N_INSTANCE_AI_MODEL_API_KEY` is read only for a custom OpenAI-compatible endpoint
+configured through `instance_ai.model_url`. Put the key under `main.secret` so it lands in the
+Secret rather than the ConfigMap:
+
+```yaml
+main:
+  secret:
+    anthropic_api_key: "<your-anthropic-api-key>"
+```
+
 See [examples/values_sandbox.yaml](examples/values_sandbox.yaml) for a complete file.
 
 ### Cluster prerequisites
@@ -958,6 +972,12 @@ so the cluster has to be prepared first:
   CoreOS. It needs `runner.acknowledgePrivileged: true` and the namespace labelled
   `pod-security.kubernetes.io/enforce=privileged`. **An escape from the runner container reaches the
   node.** Prefer a dedicated node pool.
+
+  Label the namespace *before* installing. Neither `helm template` nor
+  `kubectl apply --dry-run=server` catches a missing label: Pod Security Admission only rejects the
+  pod when the StatefulSet controller creates it, so the install succeeds and the runner stays at
+  `0/1` with a `FailedCreate` event reading
+  `violates PodSecurity "baseline:latest": privileged`.
 
   `runner.privileged.runtime.hostUsers: false` scopes those capabilities to a pod user namespace,
   which narrows the blast radius without making it a boundary. Kubernetes >= 1.33 with
@@ -980,9 +1000,31 @@ so the cluster has to be prepared first:
   issuer such as Let's Encrypt cannot serve this; use `tls.mode: certManager` with a self-signed CA
   issuer, or `tls.mode: existingSecret` with certificates you manage.
 
+* **Resources.** Upstream sets none for the API or the runner. The runner is the largest pod in
+  the release, one dockerd plus every sandbox container it starts (`defaultMemoryMb: 512` each),
+  so on shared nodes give it requests and a limit through `n8n-sandbox-service.runner.resources`.
+  The example uses requests of 500m CPU and 1Gi memory with a 4Gi memory limit; leave it unbounded
+  only on a node pool of its own.
+
 Anything under `n8n-sandbox-service` goes to the upstream chart untouched. Its
 [README](https://github.com/n8n-io/n8n-sandbox-service/tree/main/charts/n8n-sandbox-service)
 is the reference for those values, including disk quotas, NetworkPolicy and ServiceMonitor.
+
+### After the install
+
+n8n stores Instance AI settings an owner changes in the UI in its database, and those take
+precedence over the environment. On an instance where the sandbox was ever switched off in
+*Settings > AI Assistant*, the chart values look right yet the assistant reports no sandbox; the
+n8n log says so at startup:
+
+```
+Sandbox: enabled=false provider=n8n-sandbox (DB override; env was enabled=true provider=n8n-sandbox)
+```
+
+Re-enable it in *Settings > AI Assistant*, or as an owner with
+`PUT /rest/instance-ai/settings` and `{"sandboxEnabled": true}`. The same page reports
+*Setup required* until web search is either configured or explicitly disabled there, even though
+model and sandbox are already detected from the environment.
 
 ### Licensing
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ Use this structure to orient yourself.
 3. Main n8n app configuration + Kubernetes specific settings
 4. Worker related settings + Kubernetes specific settings
 5. Webhook related settings + Kubernetes specific settings
-6. Raw Resources to pass through your own manifests like GatewayAPI, ServiceMonitor etc.
-7. Redis related settings + Kubernetes specific settings
+6. Sandbox, the isolated execution environment the instance-ai module needs
+7. Raw Resources to pass through your own manifests like GatewayAPI, ServiceMonitor etc.
+8. Valkey/Redis related settings + Kubernetes specific settings
 
 ## Configurating N8n via Values and Environment Variables
 
@@ -837,8 +838,9 @@ sandbox:
     #  Secret holding the sandbox API key, which has to match the key the sandbox API accepts.
     #  Defaults to the auth Secret of the deployed subchart. Required when deploy is false.
     existingSecret: ""
-    #  Key within that Secret.
-    key: api-keys
+    #  Key within that Secret. Empty follows the deployed subchart's auth.secretKeys.apiKeys, or
+    #  api-keys when nothing is deployed.
+    key: ""
 
   #  Which n8n components receive the sandbox connection. The AI Assistant runs in the main
   #  instance; add worker when your workflows execute sandbox-backed agent nodes.
@@ -919,10 +921,15 @@ sandbox instead of in the n8n pod. The `sandbox` section connects n8n to an
 [n8n Sandbox Service](https://github.com/n8n-io/n8n-sandbox-service) and, with
 `sandbox.deploy: true`, deploys one as a subchart in the same release.
 
-The chart supplies only the two facts you cannot write by hand: it derives `N8N_SANDBOX_SERVICE_URL`
-from the sandbox API Service and reads `N8N_SANDBOX_SERVICE_API_KEY` straight out of the sandbox's
-own Secret. Switching the feature on stays with you, in `main.config`, because a container
-environment entry would silently override whatever the ConfigMap holds:
+The chart supplies only the two facts you cannot write by hand. With `sandbox.deploy: true` it
+derives `N8N_SANDBOX_SERVICE_URL` from the sandbox API Service and reads `N8N_SANDBOX_SERVICE_API_KEY`
+straight out of the sandbox's own Secret. With `sandbox.deploy: false` you supply both yourself,
+through `sandbox.url` and `sandbox.apiKey.existingSecret`, and rendering fails until you do. The
+derived URL is plain HTTP to a ClusterIP Service in the release namespace, because the upstream API
+serves no TLS on that port. The key it carries in the `X-Api-Key` header is the sandbox's admin key,
+so a sandbox reached across a trust boundary belongs behind a TLS ingress with an `https://` value
+in `sandbox.url`. Switching the feature on stays with you, in `main.config`,
+because a container environment entry would silently override whatever the ConfigMap holds:
 
 ```yaml
 main:
@@ -957,10 +964,12 @@ so the cluster has to be prepared first:
   containerd >= 2.0 is necessary but *not* sufficient: the node also needs
   `user.max_user_namespaces` above 0. Talos ships it at `0`, and there the runner pod never starts
   — the pod sandbox fails with `unshare: fork/exec /proc/self/exe: no space left on device`, which
-  is the kernel refusing a new user namespace, not a full disk. Check it before enabling:
+  is the kernel refusing a new user namespace, not a full disk. Check it before enabling, on a node
+  from the pool the runner will schedule to, since pools can differ:
 
   ```console
   $ kubectl run sysctl-probe --rm -it --image=busybox --restart=Never \
+      --overrides='{"spec":{"nodeName":"<node>"}}' \
       -- cat /proc/sys/user/max_user_namespaces
   ```
 

--- a/README.md
+++ b/README.md
@@ -950,9 +950,21 @@ so the cluster has to be prepared first:
   has to modify the node filesystem and containerd config: Talos, Bottlerocket, Flatcar and Fedora
   CoreOS. It needs `runner.acknowledgePrivileged: true` and the namespace labelled
   `pod-security.kubernetes.io/enforce=privileged`. **An escape from the runner container reaches the
-  node.** On Kubernetes >= 1.33 with containerd >= 2.0, `runner.privileged.runtime.hostUsers: false`
-  scopes those capabilities to a pod user namespace, which narrows the blast radius without making
-  it a boundary. Prefer a dedicated node pool either way.
+  node.** Prefer a dedicated node pool.
+
+  `runner.privileged.runtime.hostUsers: false` scopes those capabilities to a pod user namespace,
+  which narrows the blast radius without making it a boundary. Kubernetes >= 1.33 with
+  containerd >= 2.0 is necessary but *not* sufficient: the node also needs
+  `user.max_user_namespaces` above 0. Talos ships it at `0`, and there the runner pod never starts
+  — the pod sandbox fails with `unshare: fork/exec /proc/self/exe: no space left on device`, which
+  is the kernel refusing a new user namespace, not a full disk. Check it before enabling:
+
+  ```console
+  $ kubectl run sysctl-probe --rm -it --image=busybox --restart=Never \
+      -- cat /proc/sys/user/max_user_namespaces
+  ```
+
+  Leave `hostUsers: null` when it reads `0`.
 * GKE Autopilot blocks both. Run the data plane outside the cluster there
   (`dataPlane.mode: external`) and point `sandbox.url` at it.
 * The API and runners speak gRPC over **mutual TLS**, so they need a *private* CA. A public ACME

--- a/README.md
+++ b/README.md
@@ -808,6 +808,62 @@ webhook:
   terminationGracePeriodSeconds: 30
 
 #
+# Sandbox, the isolated execution environment the instance-ai module needs
+#
+
+#  n8n's instance-ai module (AI Assistant, agent code execution) runs generated code inside a
+#  sandbox rather than in the n8n pod. This section connects n8n to an n8n Sandbox Service and can
+#  optionally deploy one. See https://github.com/n8n-io/n8n-sandbox-service
+sandbox:
+  #  Set N8N_SANDBOX_SERVICE_URL and N8N_SANDBOX_SERVICE_API_KEY on the components in wireInto.
+  #  This only supplies the connection; enable the feature itself through main.config, for example
+  #  n8n.enabled_modules and n8n.instance_ai.sandbox.enabled. Doing it here instead would emit a
+  #  container env entry, which silently overrides whatever main.config puts in the ConfigMap.
+  enabled: false
+
+  #  Also deploy the upstream n8n-sandbox-service chart as part of this release. Leave false to point
+  #  n8n at a sandbox that lives elsewhere, or at a hosted provider.
+  #
+  #  The runner needs Docker-in-Docker privileges the chart cannot grant itself: either sysbox on the
+  #  nodes, or runner.isolation=privileged with a Pod Security Admission privileged namespace. Read
+  #  the Sandbox section of the README before turning this on.
+  deploy: false
+
+  #  Base URL of the sandbox API. Defaults to the API Service of the deployed subchart, so it only
+  #  needs a value when deploy is false.
+  url: ""
+
+  apiKey:
+    #  Secret holding the sandbox API key, which has to match the key the sandbox API accepts.
+    #  Defaults to the auth Secret of the deployed subchart. Required when deploy is false.
+    existingSecret: ""
+    #  Key within that Secret.
+    key: api-keys
+
+  #  Which n8n components receive the sandbox connection. The AI Assistant runs in the main
+  #  instance; add worker when your workflows execute sandbox-backed agent nodes.
+  wireInto:
+    - main
+
+#  Values for the upstream n8n-sandbox-service subchart, rendered when sandbox.deploy is true.
+#  Full reference: https://github.com/n8n-io/n8n-sandbox-service/tree/main/charts/n8n-sandbox-service
+n8n-sandbox-service: {}
+#  auth:
+#    #  Prefer an existingSecret in production. The subchart refuses to render on placeholder values.
+#    existingSecret: n8n-sandbox-auth
+#  runner:
+#    #  sysbox (default) needs sysbox installed on the nodes. Use privileged on clusters that cannot
+#    #  install it, such as Talos, Bottlerocket, Flatcar and Fedora CoreOS.
+#    isolation: sysbox
+#  tls:
+#    #  The API and runners speak gRPC over mutual TLS, so they need a private CA, not a public one.
+#    mode: certManager
+#    certManager:
+#      issuerRef:
+#        name: sandbox-ca
+#        kind: ClusterIssuer
+
+#
 # User defined supplementary K8s manifests
 #
 
@@ -856,6 +912,64 @@ valkey:
   #   enabled: false
   #   requestedSize: 2Gi
 ```
+## Sandbox for the AI Assistant
+
+n8n's `instance-ai` module (AI Assistant, agent code execution) runs generated code inside a
+sandbox instead of in the n8n pod. The `sandbox` section connects n8n to an
+[n8n Sandbox Service](https://github.com/n8n-io/n8n-sandbox-service) and, with
+`sandbox.deploy: true`, deploys one as a subchart in the same release.
+
+The chart supplies only the two facts you cannot write by hand: it derives `N8N_SANDBOX_SERVICE_URL`
+from the sandbox API Service and reads `N8N_SANDBOX_SERVICE_API_KEY` straight out of the sandbox's
+own Secret. Switching the feature on stays with you, in `main.config`, because a container
+environment entry would silently override whatever the ConfigMap holds:
+
+```yaml
+main:
+  config:
+    n8n:
+      enabled_modules: "instance-ai"
+      instance_ai:
+        sandbox:
+          enabled: true
+          provider: n8n-sandbox
+```
+
+See [examples/values_sandbox.yaml](examples/values_sandbox.yaml) for a complete file.
+
+### Cluster prerequisites
+
+The sandbox runner is a Docker-in-Docker container. No chart can grant it the privileges it needs,
+so the cluster has to be prepared first:
+
+* **`runner.isolation: sysbox`** (the upstream default, and the recommended one) needs
+  [sysbox](https://github.com/nestybox/sysbox/blob/master/docs/user-guide/install-k8s.md) installed
+  on the nodes. Its installer labels them `sysbox-install=yes` and registers a `sysbox-runc`
+  RuntimeClass, which the runner pod then requests.
+* **`runner.isolation: privileged`** is for clusters where sysbox cannot install at all, because it
+  has to modify the node filesystem and containerd config: Talos, Bottlerocket, Flatcar and Fedora
+  CoreOS. It needs `runner.acknowledgePrivileged: true` and the namespace labelled
+  `pod-security.kubernetes.io/enforce=privileged`. **An escape from the runner container reaches the
+  node.** On Kubernetes >= 1.33 with containerd >= 2.0, `runner.privileged.runtime.hostUsers: false`
+  scopes those capabilities to a pod user namespace, which narrows the blast radius without making
+  it a boundary. Prefer a dedicated node pool either way.
+* GKE Autopilot blocks both. Run the data plane outside the cluster there
+  (`dataPlane.mode: external`) and point `sandbox.url` at it.
+* The API and runners speak gRPC over **mutual TLS**, so they need a *private* CA. A public ACME
+  issuer such as Let's Encrypt cannot serve this; use `tls.mode: certManager` with a self-signed CA
+  issuer, or `tls.mode: existingSecret` with certificates you manage.
+
+Anything under `n8n-sandbox-service` goes to the upstream chart untouched. Its
+[README](https://github.com/n8n-io/n8n-sandbox-service/tree/main/charts/n8n-sandbox-service)
+is the reference for those values, including disk quotas, NetworkPolicy and ServiceMonitor.
+
+### Licensing
+
+The n8n Sandbox Service is covered by n8n's
+[Sustainable Use License](https://github.com/n8n-io/n8n-sandbox-service/blob/main/LICENSE.md), and
+its Firecracker runner requires an n8n Enterprise licence. That is a different licence from this
+chart's own, so review it before deploying the subchart.
+
 ## Migration Guide to Version 1.0.0
 
 This version includes a complete redesign of the chart to better accommodate n8n configuration options.

--- a/charts/n8n/Chart.lock
+++ b/charts/n8n/Chart.lock
@@ -1,6 +1,9 @@
 dependencies:
+- name: n8n-sandbox-service
+  repository: oci://ghcr.io/n8n-io/n8n-sandbox-service
+  version: 0.6.3
 - name: valkey
   repository: https://valkey.io/valkey-helm/
   version: 0.8.1
-digest: sha256:9f554436d4d0d4b2817ab949eb90d2ddcc770fc5e60278bfed353d5fece6d5a6
-generated: "2025-12-01T23:58:16.062167+01:00"
+digest: sha256:6dc9727c011a25b78a08a422538a253ba09f354979ee6e2baa5f20fc977d93ee
+generated: "2026-09-03T16:00:47.701869+02:00"

--- a/charts/n8n/Chart.yaml
+++ b/charts/n8n/Chart.yaml
@@ -27,6 +27,10 @@ maintainers:
     url: https://github.com/n8n-io
 
 dependencies:
+  - name: n8n-sandbox-service
+    version: 0.6.3
+    repository: oci://ghcr.io/n8n-io/n8n-sandbox-service
+    condition: sandbox.deploy
   - name: valkey
     version: 0.8.1
     repository: https://valkey.io/valkey-helm/
@@ -47,11 +51,7 @@ annotations:
       url: https://docs.n8n.io/hosting/configuration/environment-variables/
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "Readiness probes now use /healthz/readiness, so a pod that lost its database connection is removed from the Service instead of staying Ready on /healthz"
     - kind: added
-      description: "Added a startupProbe to the main, worker and webhook pods, so the liveness probe no longer kills containers that are still running migrations"
-    - kind: fixed
-      description: "Worker pods now default QUEUE_HEALTH_CHECK_ACTIVE to true and expose the queue health check port, without which the worker probes could never pass"
-    - kind: changed
-      description: "Updated n8n to 2.36.8, the current stable release"
+      description: "Added an optional sandbox section that wires n8n to an n8n Sandbox Service, the isolated execution environment the instance-ai module needs"
+    - kind: added
+      description: "Added the upstream n8n-sandbox-service chart as an optional dependency, rendered when sandbox.deploy is true"

--- a/charts/n8n/templates/NOTES.txt
+++ b/charts/n8n/templates/NOTES.txt
@@ -20,3 +20,12 @@
   echo "Visit http://127.0.0.1:8080 to use your application"
   kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
 {{- end }}
+{{- if .Values.sandbox.enabled }}
+{{- range $component := default (list) .Values.sandbox.wireInto }}
+{{- if and (ne $component "main") (not (index $.Values $component).enabled) }}
+
+WARNING: sandbox.wireInto lists "{{ $component }}" but {{ $component }}.enabled is false. No {{ $component }} pod
+         was created, so nothing is wired there. Enable it or drop it from sandbox.wireInto.
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -103,3 +103,64 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 
+
+
+{{/* Fully qualified name of the sandbox API Service.
+     This mirrors the fullname helper of the upstream n8n-sandbox-service chart. That coupling is
+     the price of deriving the URL for the user; re-check it against their _helpers.tpl whenever the
+     dependency version in Chart.yaml moves. */}}
+{{- define "n8n.sandboxApiName" -}}
+{{- include "n8n.sandboxFullname" . }}-api
+{{- end -}}
+
+{{- define "n8n.sandboxFullname" -}}
+{{- $values := default (dict) (index .Values "n8n-sandbox-service") -}}
+{{- if $values.fullnameOverride -}}
+{{- $values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "n8n-sandbox-service" $values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Base URL n8n uses to reach the sandbox API */}}
+{{- define "n8n.sandboxUrl" -}}
+{{- if .Values.sandbox.url -}}
+{{- .Values.sandbox.url -}}
+{{- else if .Values.sandbox.deploy -}}
+{{- $values := default (dict) (index .Values "n8n-sandbox-service") -}}
+{{- printf "http://%s.%s.svc:%v" (include "n8n.sandboxApiName" .) .Release.Namespace (dig "api" "service" "httpPort" 8080 $values) -}}
+{{- else -}}
+{{- fail "sandbox.enabled needs a sandbox to talk to: set sandbox.url, or sandbox.deploy=true to run one in this release" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Secret holding the sandbox API key */}}
+{{- define "n8n.sandboxSecretName" -}}
+{{- if .Values.sandbox.apiKey.existingSecret -}}
+{{- .Values.sandbox.apiKey.existingSecret -}}
+{{- else if .Values.sandbox.deploy -}}
+{{- $values := default (dict) (index .Values "n8n-sandbox-service") -}}
+{{- default (printf "%s-auth" (include "n8n.sandboxFullname" .)) (dig "auth" "existingSecret" "" $values) | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- fail "sandbox.enabled needs an API key: set sandbox.apiKey.existingSecret, or sandbox.deploy=true to let the subchart own the Secret" -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Connection environment for a component listed in sandbox.wireInto.
+     Only the two connection facts live here. Everything that switches the feature on belongs in
+     main.config/main.secret, because a container env entry wins over envFrom and would quietly
+     override the user's own value. */}}
+{{- define "n8n.sandboxEnv" -}}
+- name: N8N_SANDBOX_SERVICE_URL
+  value: {{ include "n8n.sandboxUrl" . | quote }}
+- name: N8N_SANDBOX_SERVICE_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "n8n.sandboxSecretName" . }}
+      key: {{ .Values.sandbox.apiKey.key }}
+{{- end -}}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -187,8 +187,8 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 - name: N8N_SANDBOX_SERVICE_API_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ include "n8n.sandboxSecretName" $root }}
-      key: {{ include "n8n.sandboxSecretKey" $root }}
+      name: {{ include "n8n.sandboxSecretName" $root | quote }}
+      key: {{ include "n8n.sandboxSecretKey" $root | quote }}
 {{- end -}}
 
 {{/* A misspelt component in sandbox.wireInto would otherwise deploy silently unwired */}}

--- a/charts/n8n/templates/_helpers.tpl
+++ b/charts/n8n/templates/_helpers.tpl
@@ -110,7 +110,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
      the price of deriving the URL for the user; re-check it against their _helpers.tpl whenever the
      dependency version in Chart.yaml moves. */}}
 {{- define "n8n.sandboxApiName" -}}
-{{- include "n8n.sandboxFullname" . }}-api
+{{- printf "%s-api" (include "n8n.sandboxFullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{- define "n8n.sandboxFullname" -}}
@@ -151,16 +151,70 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{/* Key inside that Secret holding the API key. Follows the subchart's auth.secretKeys.apiKeys
+     when the subchart owns the Secret, for the same reason the name does: a rename upstream must
+     not leave the n8n pod pointing at a key that no longer exists. */}}
+{{- define "n8n.sandboxSecretKey" -}}
+{{- $explicit := .Values.sandbox.apiKey.key -}}
+{{- if and .Values.sandbox.deploy (not .Values.sandbox.apiKey.existingSecret) -}}
+{{- $sbx := default (dict) (index .Values "n8n-sandbox-service") -}}
+{{- $keys := default (dict) (get (default (dict) (get $sbx "auth")) "secretKeys") -}}
+{{- $upstream := default "api-keys" (get $keys "apiKeys") -}}
+{{- if and $explicit (ne $explicit $upstream) -}}
+{{- fail (printf "sandbox.apiKey.key %q does not exist in the Secret the sandbox subchart writes; it stores the API key under %q (n8n-sandbox-service.auth.secretKeys.apiKeys). Drop sandbox.apiKey.key to follow it" $explicit $upstream) -}}
+{{- end -}}
+{{- $upstream -}}
+{{- else -}}
+{{- default "api-keys" $explicit -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Connection environment for a component listed in sandbox.wireInto.
+     Takes a dict with "root" (the chart context) and "extraEnv" (that component's extraEnv map).
      Only the two connection facts live here. Everything that switches the feature on belongs in
      main.config/main.secret, because a container env entry wins over envFrom and would quietly
-     override the user's own value. */}}
+     override the user's own value. The same two names in extraEnv would yield a duplicate env
+     entry with no defined winner, so that is refused rather than resolved. */}}
 {{- define "n8n.sandboxEnv" -}}
+{{- $root := .root -}}
+{{- range $name := list "N8N_SANDBOX_SERVICE_URL" "N8N_SANDBOX_SERVICE_API_KEY" -}}
+{{- if hasKey (default (dict) $.extraEnv) $name -}}
+{{- fail (printf "%s is set by the sandbox section; remove it from extraEnv or drop that component from sandbox.wireInto" $name) -}}
+{{- end -}}
+{{- end -}}
 - name: N8N_SANDBOX_SERVICE_URL
-  value: {{ include "n8n.sandboxUrl" . | quote }}
+  value: {{ include "n8n.sandboxUrl" $root | quote }}
 - name: N8N_SANDBOX_SERVICE_API_KEY
   valueFrom:
     secretKeyRef:
-      name: {{ include "n8n.sandboxSecretName" . }}
-      key: {{ .Values.sandbox.apiKey.key }}
+      name: {{ include "n8n.sandboxSecretName" $root }}
+      key: {{ include "n8n.sandboxSecretKey" $root }}
+{{- end -}}
+
+{{/* A misspelt component in sandbox.wireInto would otherwise deploy silently unwired */}}
+{{- define "n8n.sandboxValidateWireInto" -}}
+{{- if .Values.sandbox.enabled -}}
+{{- range $component := default (list) .Values.sandbox.wireInto -}}
+{{- if not (has $component (list "main" "worker" "webhook")) -}}
+{{- fail (printf "sandbox.wireInto: unknown component %q; use main, worker or webhook" (toString $component)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Checksum input for a component's pod template. Takes a dict with "root" and "component".
+     Everything under sandbox.* already shows in the pod template and rolls it on its own; the one
+     thing the pod cannot see change is the API key inside the subchart's generated Secret, because
+     Kubernetes never refreshes a secretKeyRef in a running container. So that value, and only
+     that value, is hashed, and only for a component that reads it. A disabled feature contributes
+     nothing, which keeps the hash of an existing release identical across the upgrade. Null-safe
+     on purpose: --set n8n-sandbox-service.auth=null is a legitimate way to drop the defaults. */}}
+{{- define "n8n.sandboxChecksumInput" -}}
+{{- $v := .root.Values -}}
+{{- if and $v.sandbox.enabled $v.sandbox.deploy (not $v.sandbox.apiKey.existingSecret) (has .component (default (list) $v.sandbox.wireInto)) -}}
+{{- $auth := default (dict) (get (default (dict) (index $v "n8n-sandbox-service")) "auth") -}}
+{{- if not (get $auth "existingSecret") -}}
+{{- print (get (default (dict) (get $auth "generated")) "apiKeys") -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -33,7 +33,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ print .Values.webhook .Values.main | sha256sum }}
+        checksum/config: {{ print .Values.webhook .Values.main .Values.sandbox | sha256sum }}
         {{- with .Values.webhook.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -106,7 +106,11 @@ spec:
                 name: {{ include "n8n.fullname" . }}-webhook-secret
             {{- end }}
 
-          env: {{ not (empty .Values.webhook.extraEnv) | ternary nil "[]" }}
+          {{- $sandboxWired := and .Values.sandbox.enabled (has "webhook" (default (list) .Values.sandbox.wireInto)) }}
+          env: {{ or (not (empty .Values.webhook.extraEnv)) $sandboxWired | ternary nil "[]" }}
+            {{- if $sandboxWired }}
+            {{- include "n8n.sandboxEnv" . | nindent 12 }}
+            {{- end }}
             {{- range $key, $value := .Values.webhook.extraEnv }}
             - name: {{ $key }}
               {{- toYaml $value | nindent 14 }}

--- a/charts/n8n/templates/deployment.webhook.yaml
+++ b/charts/n8n/templates/deployment.webhook.yaml
@@ -33,7 +33,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ print .Values.webhook .Values.main .Values.sandbox | sha256sum }}
+        checksum/config: {{ print .Values.webhook .Values.main (include "n8n.sandboxChecksumInput" (dict "root" . "component" "webhook")) | sha256sum }}
         {{- with .Values.webhook.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -109,7 +109,7 @@ spec:
           {{- $sandboxWired := and .Values.sandbox.enabled (has "webhook" (default (list) .Values.sandbox.wireInto)) }}
           env: {{ or (not (empty .Values.webhook.extraEnv)) $sandboxWired | ternary nil "[]" }}
             {{- if $sandboxWired }}
-            {{- include "n8n.sandboxEnv" . | nindent 12 }}
+            {{- include "n8n.sandboxEnv" (dict "root" . "extraEnv" .Values.webhook.extraEnv) | nindent 12 }}
             {{- end }}
             {{- range $key, $value := .Values.webhook.extraEnv }}
             - name: {{ $key }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -79,7 +79,7 @@ spec:
           {{- $sandboxWired := and .Values.sandbox.enabled (has "worker" (default (list) .Values.sandbox.wireInto)) }}
           env: {{ or (not (empty .Values.worker.extraEnv)) $sandboxWired | ternary nil "[]" }}
             {{- if $sandboxWired }}
-            {{- include "n8n.sandboxEnv" . | nindent 12 }}
+            {{- include "n8n.sandboxEnv" (dict "root" . "extraEnv" .Values.worker.extraEnv) | nindent 12 }}
             {{- end }}
             {{- range $key, $value := .Values.worker.extraEnv }}
             - name: {{ $key }}

--- a/charts/n8n/templates/deployment.worker.yaml
+++ b/charts/n8n/templates/deployment.worker.yaml
@@ -76,7 +76,11 @@ spec:
             - secretRef:
                 name: {{ include "n8n.fullname" . }}-worker-secret
             {{- end }}
-          env: {{ not (empty .Values.worker.extraEnv) | ternary nil "[]" }}
+          {{- $sandboxWired := and .Values.sandbox.enabled (has "worker" (default (list) .Values.sandbox.wireInto)) }}
+          env: {{ or (not (empty .Values.worker.extraEnv)) $sandboxWired | ternary nil "[]" }}
+            {{- if $sandboxWired }}
+            {{- include "n8n.sandboxEnv" . | nindent 12 }}
+            {{- end }}
             {{- range $key, $value := .Values.worker.extraEnv }}
             - name: {{ $key }}
               {{- toYaml $value | nindent 14 }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "n8n.sandboxValidateWireInto" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -30,7 +31,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ print .Values.main .Values.sandbox | sha256sum }}
+        checksum/config: {{ print .Values.main (include "n8n.sandboxChecksumInput" (dict "root" . "component" "main")) | sha256sum }}
         {{- with .Values.main.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -76,7 +77,7 @@ spec:
           {{- $sandboxWired := and .Values.sandbox.enabled (has "main" (default (list) .Values.sandbox.wireInto)) }}
           env: {{ or (not (empty .Values.main.extraEnv)) $sandboxWired | ternary nil "[]" }}
             {{- if $sandboxWired }}
-            {{- include "n8n.sandboxEnv" . | nindent 12 }}
+            {{- include "n8n.sandboxEnv" (dict "root" . "extraEnv" .Values.main.extraEnv) | nindent 12 }}
             {{- end }}
             {{- range $key, $value := .Values.main.extraEnv }}
             - name: {{ $key }}

--- a/charts/n8n/templates/deployment.yaml
+++ b/charts/n8n/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ print .Values.main | sha256sum }}
+        checksum/config: {{ print .Values.main .Values.sandbox | sha256sum }}
         {{- with .Values.main.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -73,7 +73,11 @@ spec:
             - secretRef:
                 name: {{ include "n8n.fullname" . }}-app-secret
             {{- end }}
-          env: {{ not (empty .Values.main.extraEnv) | ternary nil "[]" }}
+          {{- $sandboxWired := and .Values.sandbox.enabled (has "main" (default (list) .Values.sandbox.wireInto)) }}
+          env: {{ or (not (empty .Values.main.extraEnv)) $sandboxWired | ternary nil "[]" }}
+            {{- if $sandboxWired }}
+            {{- include "n8n.sandboxEnv" . | nindent 12 }}
+            {{- end }}
             {{- range $key, $value := .Values.main.extraEnv }}
             - name: {{ $key }}
               {{- toYaml $value | nindent 14 }}

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -737,8 +737,9 @@ sandbox:
     #  Secret holding the sandbox API key, which has to match the key the sandbox API accepts.
     #  Defaults to the auth Secret of the deployed subchart. Required when deploy is false.
     existingSecret: ""
-    #  Key within that Secret.
-    key: api-keys
+    #  Key within that Secret. Empty follows the deployed subchart's auth.secretKeys.apiKeys, or
+    #  api-keys when nothing is deployed.
+    key: ""
 
   #  Which n8n components receive the sandbox connection. The AI Assistant runs in the main
   #  instance; add worker when your workflows execute sandbox-backed agent nodes.

--- a/charts/n8n/values.yaml
+++ b/charts/n8n/values.yaml
@@ -5,8 +5,9 @@
 # 3. Main n8n app configuration + kubernetes specific settings
 # 4. Worker related settings + kubernetes specific settings
 # 5. Webhook related settings + kubernetes specific settings
-# 6. Raw Resources to pass through your own manifests like GatewayAPI, ServiceMonitor etc.
-# 7. Valkey/Redis related settings and kubernetes specific settings
+# 6. Sandbox, the isolated execution environment the instance-ai module needs
+# 7. Raw Resources to pass through your own manifests like GatewayAPI, ServiceMonitor etc.
+# 8. Valkey/Redis related settings and kubernetes specific settings
 
 #
 # Global common config for this entire n8n deployment
@@ -705,6 +706,62 @@ webhook:
 
   # Pod termination grace period in seconds
   terminationGracePeriodSeconds: 30
+
+#
+# Sandbox, the isolated execution environment the instance-ai module needs
+#
+
+#  n8n's instance-ai module (AI Assistant, agent code execution) runs generated code inside a
+#  sandbox rather than in the n8n pod. This section connects n8n to an n8n Sandbox Service and can
+#  optionally deploy one. See https://github.com/n8n-io/n8n-sandbox-service
+sandbox:
+  #  Set N8N_SANDBOX_SERVICE_URL and N8N_SANDBOX_SERVICE_API_KEY on the components in wireInto.
+  #  This only supplies the connection; enable the feature itself through main.config, for example
+  #  n8n.enabled_modules and n8n.instance_ai.sandbox.enabled. Doing it here instead would emit a
+  #  container env entry, which silently overrides whatever main.config puts in the ConfigMap.
+  enabled: false
+
+  #  Also deploy the upstream n8n-sandbox-service chart as part of this release. Leave false to point
+  #  n8n at a sandbox that lives elsewhere, or at a hosted provider.
+  #
+  #  The runner needs Docker-in-Docker privileges the chart cannot grant itself: either sysbox on the
+  #  nodes, or runner.isolation=privileged with a Pod Security Admission privileged namespace. Read
+  #  the Sandbox section of the README before turning this on.
+  deploy: false
+
+  #  Base URL of the sandbox API. Defaults to the API Service of the deployed subchart, so it only
+  #  needs a value when deploy is false.
+  url: ""
+
+  apiKey:
+    #  Secret holding the sandbox API key, which has to match the key the sandbox API accepts.
+    #  Defaults to the auth Secret of the deployed subchart. Required when deploy is false.
+    existingSecret: ""
+    #  Key within that Secret.
+    key: api-keys
+
+  #  Which n8n components receive the sandbox connection. The AI Assistant runs in the main
+  #  instance; add worker when your workflows execute sandbox-backed agent nodes.
+  wireInto:
+    - main
+
+#  Values for the upstream n8n-sandbox-service subchart, rendered when sandbox.deploy is true.
+#  Full reference: https://github.com/n8n-io/n8n-sandbox-service/tree/main/charts/n8n-sandbox-service
+n8n-sandbox-service: {}
+#  auth:
+#    #  Prefer an existingSecret in production. The subchart refuses to render on placeholder values.
+#    existingSecret: n8n-sandbox-auth
+#  runner:
+#    #  sysbox (default) needs sysbox installed on the nodes. Use privileged on clusters that cannot
+#    #  install it, such as Talos, Bottlerocket, Flatcar and Fedora CoreOS.
+#    isolation: sysbox
+#  tls:
+#    #  The API and runners speak gRPC over mutual TLS, so they need a private CA, not a public one.
+#    mode: certManager
+#    certManager:
+#      issuerRef:
+#        name: sandbox-ca
+#        kind: ClusterIssuer
 
 #
 # User defined supplementary K8s manifests

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ for to help you get started with a setup for your particular use case.
 * values_local.yaml - n8n on local kind/k3s cluster for testing on localhost
 * aws - n8n on AWS with EKS, ingress-nginx
 * simple-prod -  simple production setup with AWS
+* values_sandbox.yaml - n8n with an in-cluster n8n Sandbox Service for the instance-ai module
 
 ## Render Examples
 

--- a/examples/values_sandbox.yaml
+++ b/examples/values_sandbox.yaml
@@ -7,16 +7,17 @@
 #   * cert-manager plus a *private* CA issuer. The API and runners speak gRPC over mutual
 #     TLS, so a public ACME issuer such as Let's Encrypt cannot serve this.
 #
-# A private CA issuer, if you do not already have one:
+# A private CA issuer, if you do not already have one. Apply it into the namespace you install
+# this release into; an Issuer is namespaced and the subchart looks it up next to itself.
 #
 #   apiVersion: cert-manager.io/v1
 #   kind: Issuer
-#   metadata: {name: sandbox-selfsigned, namespace: n8n}
+#   metadata: {name: sandbox-selfsigned}
 #   spec: {selfSigned: {}}
 #   ---
 #   apiVersion: cert-manager.io/v1
 #   kind: Certificate
-#   metadata: {name: sandbox-ca, namespace: n8n}
+#   metadata: {name: sandbox-ca}
 #   spec:
 #     isCA: true
 #     commonName: sandbox-ca
@@ -26,8 +27,20 @@
 #   ---
 #   apiVersion: cert-manager.io/v1
 #   kind: Issuer
-#   metadata: {name: sandbox-ca, namespace: n8n}
+#   metadata: {name: sandbox-ca}
 #   spec: {ca: {secretName: sandbox-ca}}
+#
+# The sandbox API keys, created out of band so nothing predictable ever lands in a values file.
+# Same namespace rule as the Issuer above. The API uses api-keys, runner-registration-token and
+# runner-api-key; the runner uses runner-api-keys and runner-registration-token, so the two runner
+# values must match.
+#
+#   RUNNER_KEY=$(openssl rand -hex 32)
+#   kubectl create secret generic n8n-sandbox-auth -n <release namespace> \
+#     --from-literal=api-keys=$(openssl rand -hex 32) \
+#     --from-literal=runner-registration-token=$(openssl rand -hex 32) \
+#     --from-literal=runner-api-key=$RUNNER_KEY \
+#     --from-literal=runner-api-keys=$RUNNER_KEY
 
 main:
   config:
@@ -54,24 +67,23 @@ main:
     size: 2Gi
 
 # Connect n8n to the sandbox and deploy one alongside it. The chart derives the API URL and
-# reads the key straight from the subchart's Secret, so neither is repeated here.
+# reads the key straight from the subchart's Secret, so neither is repeated here. The derived
+# URL is plain HTTP to a ClusterIP Service in this namespace; the upstream API serves no TLS on
+# that port. Anything that crosses a trust boundary goes through a TLS ingress instead, see below.
 sandbox:
   enabled: true
   deploy: true
   wireInto:
     - main
 
-# Upstream chart values. Full reference:
+# Upstream chart values. Reference (upstream main; this chart pins the version in Chart.yaml):
 # https://github.com/n8n-io/n8n-sandbox-service/tree/main/charts/n8n-sandbox-service
 n8n-sandbox-service:
   auth:
-    # Placeholders are rejected by the subchart. In production create the Secret out of band
-    # and set auth.existingSecret instead, so the keys never sit in a values file.
-    generated:
-      apiKeys: "<random-api-key>"
-      runnerRegistrationToken: "<random-registration-token>"
-      runnerApiKey: "<random-runner-api-key>"
-      runnerApiKeys: "<random-runner-api-key>"
+    # The Secret created above. Without it the subchart falls back to auth.generated, whose
+    # upstream placeholders fail the render, so a copied file cannot ship as-is. The chart reads
+    # the n8n-side key from this same Secret.
+    existingSecret: n8n-sandbox-auth
 
   tls:
     mode: certManager
@@ -100,12 +112,16 @@ n8n-sandbox-service:
     #     hostUsers: false
 
 # Alternative: run the sandbox somewhere else and only point n8n at it. Drop the whole
-# n8n-sandbox-service block above and use:
+# n8n-sandbox-service block above and use one of these. Plain http:// is only for a Service inside
+# the same cluster; the admin API key travels in an X-Api-Key header, so once the path leaves the
+# cluster put the sandbox API behind a TLS ingress (api.ingress in the upstream chart) and use
+# https://.
 #
 # sandbox:
 #   enabled: true
 #   deploy: false
-#   url: "http://n8n-sandbox-service-api.sandbox.svc:8080"
+#   url: "http://n8n-sandbox-service-api.sandbox.svc:8080"   # same cluster, other namespace
+#   # url: "https://sandbox.example.com"                       # anywhere else, via TLS ingress
 #   apiKey:
 #     existingSecret: n8n-sandbox-auth
 #     key: api-keys

--- a/examples/values_sandbox.yaml
+++ b/examples/values_sandbox.yaml
@@ -60,9 +60,12 @@ main:
   secret:
     n8n:
       encryption_key: "<your-secure-encryption-key>"
-      instance_ai:
-        model:
-          api_key: "<your-model-provider-api-key>"
+    # A built-in provider reads its own SDK variable, chosen by the prefix of instance_ai.model:
+    # anthropic -> ANTHROPIC_API_KEY, openai -> OPENAI_API_KEY, google -> GOOGLE_GENERATIVE_AI_API_KEY,
+    # mistral -> MISTRAL_API_KEY, groq, cohere, deepseek, openrouter and xai likewise.
+    # N8N_INSTANCE_AI_MODEL_API_KEY (secret.n8n.instance_ai.model.api_key) is only read for a
+    # custom OpenAI-compatible endpoint set through instance_ai.model_url.
+    anthropic_api_key: "<your-anthropic-api-key>"
 
   persistence:
     enabled: true
@@ -107,7 +110,19 @@ n8n-sandbox-service:
   #           matchLabels:
   #             app.kubernetes.io/name: n8n
 
+  api:
+    resources:
+      requests: {cpu: 100m, memory: 128Mi}
+      limits: {memory: 512Mi}
+
   runner:
+    # Upstream sets no resources. The runner is the largest pod in the release: one dockerd plus
+    # every sandbox container it starts (defaultMemoryMb: 512 each). Leave it unbounded only on
+    # a node pool of its own.
+    resources:
+      requests: {cpu: 500m, memory: 1Gi}
+      limits: {memory: 4Gi}
+
     # sysbox is the recommended isolation and needs sysbox installed on the nodes, which
     # labels them sysbox-install=yes and registers a sysbox-runc RuntimeClass.
     isolation: sysbox

--- a/examples/values_sandbox.yaml
+++ b/examples/values_sandbox.yaml
@@ -1,0 +1,109 @@
+# n8n with an in-cluster n8n Sandbox Service, the isolated execution environment the
+# instance-ai module (AI Assistant, agent code execution) runs generated code in.
+#
+# Cluster prerequisites, none of which a chart can create for you:
+#   * The runner needs Docker-in-Docker privileges. Either sysbox on the nodes (the default
+#     below), or runner.isolation=privileged on clusters that cannot install it.
+#   * cert-manager plus a *private* CA issuer. The API and runners speak gRPC over mutual
+#     TLS, so a public ACME issuer such as Let's Encrypt cannot serve this.
+#
+# A private CA issuer, if you do not already have one:
+#
+#   apiVersion: cert-manager.io/v1
+#   kind: Issuer
+#   metadata: {name: sandbox-selfsigned, namespace: n8n}
+#   spec: {selfSigned: {}}
+#   ---
+#   apiVersion: cert-manager.io/v1
+#   kind: Certificate
+#   metadata: {name: sandbox-ca, namespace: n8n}
+#   spec:
+#     isCA: true
+#     commonName: sandbox-ca
+#     secretName: sandbox-ca
+#     privateKey: {algorithm: ECDSA, size: 256}
+#     issuerRef: {name: sandbox-selfsigned, kind: Issuer, group: cert-manager.io}
+#   ---
+#   apiVersion: cert-manager.io/v1
+#   kind: Issuer
+#   metadata: {name: sandbox-ca, namespace: n8n}
+#   spec: {ca: {secretName: sandbox-ca}}
+
+main:
+  config:
+    db:
+      type: sqlite
+    n8n:
+      # instance-ai carries the AI Assistant. It is a list, so keep any module you already run.
+      enabled_modules: "instance-ai"
+      instance_ai:
+        sandbox:
+          enabled: true
+          provider: n8n-sandbox
+        model: "anthropic/claude-opus-4-8"
+  secret:
+    n8n:
+      encryption_key: "<your-secure-encryption-key>"
+      instance_ai:
+        model:
+          api_key: "<your-model-provider-api-key>"
+
+  persistence:
+    enabled: true
+    type: dynamic
+    size: 2Gi
+
+# Connect n8n to the sandbox and deploy one alongside it. The chart derives the API URL and
+# reads the key straight from the subchart's Secret, so neither is repeated here.
+sandbox:
+  enabled: true
+  deploy: true
+  wireInto:
+    - main
+
+# Upstream chart values. Full reference:
+# https://github.com/n8n-io/n8n-sandbox-service/tree/main/charts/n8n-sandbox-service
+n8n-sandbox-service:
+  auth:
+    # Placeholders are rejected by the subchart. In production create the Secret out of band
+    # and set auth.existingSecret instead, so the keys never sit in a values file.
+    generated:
+      apiKeys: "<random-api-key>"
+      runnerRegistrationToken: "<random-registration-token>"
+      runnerApiKey: "<random-runner-api-key>"
+      runnerApiKeys: "<random-runner-api-key>"
+
+  tls:
+    mode: certManager
+    certManager:
+      issuerRef:
+        name: sandbox-ca
+        kind: Issuer
+
+  runner:
+    # sysbox is the recommended isolation and needs sysbox installed on the nodes, which
+    # labels them sysbox-install=yes and registers a sysbox-runc RuntimeClass.
+    isolation: sysbox
+
+    # On Talos, Bottlerocket, Flatcar or Fedora CoreOS sysbox cannot install at all. Swap the
+    # three lines above for these, label the namespace
+    # pod-security.kubernetes.io/enforce=privileged, and understand that an escape from the
+    # runner container reaches the node. hostUsers narrows that, and needs
+    # Kubernetes >= 1.33 with containerd >= 2.0.
+    #
+    # isolation: privileged
+    # acknowledgePrivileged: true
+    # privileged:
+    #   runtime:
+    #     hostUsers: false
+
+# Alternative: run the sandbox somewhere else and only point n8n at it. Drop the whole
+# n8n-sandbox-service block above and use:
+#
+# sandbox:
+#   enabled: true
+#   deploy: false
+#   url: "http://n8n-sandbox-service-api.sandbox.svc:8080"
+#   apiKey:
+#     existingSecret: n8n-sandbox-auth
+#     key: api-keys

--- a/examples/values_sandbox.yaml
+++ b/examples/values_sandbox.yaml
@@ -8,7 +8,10 @@
 #     TLS, so a public ACME issuer such as Let's Encrypt cannot serve this.
 #
 # A private CA issuer, if you do not already have one. Apply it into the namespace you install
-# this release into; an Issuer is namespaced and the subchart looks it up next to itself.
+# this release into; an Issuer is namespaced and the subchart looks it up next to itself. Save the
+# three documents below as sandbox-ca.yaml, then:
+#
+#   kubectl apply -n <release namespace> -f sandbox-ca.yaml
 #
 #   apiVersion: cert-manager.io/v1
 #   kind: Issuer
@@ -92,6 +95,18 @@ n8n-sandbox-service:
         name: sandbox-ca
         kind: Issuer
 
+  # The API port is plain HTTP and, by default, reachable from every pod in the cluster. The
+  # upstream NetworkPolicy narrows that to the n8n pods. Use "- podSelector: {}" for the whole
+  # namespace instead, or leave httpIngressFrom empty to allow every source in the cluster, which
+  # an ingress controller in another namespace needs.
+  # networkPolicy:
+  #   enabled: true
+  #   api:
+  #     httpIngressFrom:
+  #       - podSelector:
+  #           matchLabels:
+  #             app.kubernetes.io/name: n8n
+
   runner:
     # sysbox is the recommended isolation and needs sysbox installed on the nodes, which
     # labels them sysbox-install=yes and registers a sysbox-runc RuntimeClass.
@@ -123,5 +138,8 @@ n8n-sandbox-service:
 #   url: "http://n8n-sandbox-service-api.sandbox.svc:8080"   # same cluster, other namespace
 #   # url: "https://sandbox.example.com"                       # anywhere else, via TLS ingress
 #   apiKey:
-#     existingSecret: n8n-sandbox-auth
-#     key: api-keys
+#     # A Secret in this release's namespace holding that service's admin key, the one it lists
+#     # in SANDBOX_API_KEYS. Not the Secret from the in-cluster setup above; that key was never
+#     # given to the external service.
+#     existingSecret: external-sandbox-api-key
+#     key: api-key

--- a/examples/values_sandbox.yaml
+++ b/examples/values_sandbox.yaml
@@ -95,6 +95,8 @@ n8n-sandbox-service:
     # acknowledgePrivileged: true
     # privileged:
     #   runtime:
+    #     # Only when /proc/sys/user/max_user_namespaces on the node is above 0. Talos ships it
+    #     # at 0, where the runner pod never starts. Leave this out in that case.
     #     hostUsers: false
 
 # Alternative: run the sandbox somewhere else and only point n8n at it. Drop the whole


### PR DESCRIPTION
## What

Adds an optional `sandbox` section that connects n8n to an [n8n Sandbox Service](https://github.com/n8n-io/n8n-sandbox-service) — the isolated execution environment n8n's `instance-ai` module (AI Assistant, agent code execution) runs generated code in — and can deploy one alongside n8n.

```yaml
sandbox:
  enabled: true   # wire n8n to a sandbox
  deploy: true    # and run one in this release
```

## Why not reimplement it

n8n publishes an official chart for the service, and their [Kubernetes quickstart](https://github.com/n8n-io/n8n-sandbox-service/blob/main/docs/quickstart-k8s.md) asks consumers to *"create a wrapper Helm chart that depends on `n8n-sandbox-service`"*. It already ships the runner StatefulSet, cert-manager mTLS, sysbox RuntimeClass, NetworkPolicy, ServiceMonitor and xfs disk-quota handling. So this adds it as a dependency gated on `sandbox.deploy` rather than duplicating ~12 templates we would then have to track.

## What the chart actually contributes

The n8n side needed no new plumbing — `toEnvVars` already produces every `N8N_INSTANCE_AI_*` and `N8N_ENABLED_MODULES` variable from `main.config`. What a user cannot write by hand is the sandbox API Service name and the Secret the subchart generates, so the new section derives both and injects exactly those two variables.

Feature enablement deliberately stays in `main.config`: a container `env` entry wins over `envFrom`, so setting it here would silently override whatever the user put in their ConfigMap.

`sandbox.deploy: false` keeps the same wiring for a sandbox that runs elsewhere, so external and hosted data planes are covered by the same values. Rendering fails with a message naming the missing value when `sandbox.enabled` is set without a URL or an API key, following the existing `n8n.validateValkey` precedent.

## Compatibility

Default values are unchanged: with `sandbox.enabled: false` no subchart resources render and the three deployments still emit `env: []` byte for byte.

## Testing

Rendered cases: defaults unchanged; `deploy: true`; external endpoint; `wireInto` empty; both failure paths. Full output parses with no duplicate env names. `make lint` passes (`ah lint`, `helm lint`, `ct lint` — the latter resolves the OCI dependency fine).

Installed on k3d (k3s v1.35.5) with `runner.isolation: privileged`, cert-manager and a self-signed CA issuer:

- all three pods Ready, including the privileged Docker-in-Docker runner
- runner completed mTLS registration with the API and pulled the sandbox image
- `GET /healthz` → `{"status":"ok"}`
- n8n main pod carries the derived `N8N_SANDBOX_SERVICE_URL` and the `N8N_SANDBOX_SERVICE_API_KEY` resolved from the subchart's Secret
- `POST /sandboxes` then `POST /sandboxes/{id}/executions` ran code inside a real sandbox container and returned `exit_code: 0`

## Notes for reviewers

- `n8n.sandboxApiName` mirrors the upstream chart's `fullname` helper. That coupling is the price of deriving the URL; the helper comment says to re-check it whenever the dependency version moves.
- The runner needs privileges no chart can grant itself (sysbox on the nodes, or `privileged` with a PSA `privileged` namespace). The README section spells out the prerequisites, the GKE Autopilot limitation, and that mTLS needs a *private* CA rather than a public ACME issuer.
- The sandbox service is under n8n's Sustainable Use License, which differs from this chart's own licence. Called out in the README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional integration with the n8n Sandbox Service for AI Assistant workloads.
  - Supports deploying the service alongside n8n or connecting to an existing service.
  - Enables sandbox connectivity for main, worker, and webhook components.
  - Added configuration for service URLs, API keys, security settings, and component wiring.
  - Added an example setup with TLS, isolated execution, resource settings, and provider-specific model credentials.
  - Added validation and deployment notes for unsupported or disabled component wiring.

- **Documentation**
  - Added setup guidance, cluster prerequisites, licensing information, credential configuration, and deployment considerations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->